### PR TITLE
DataBase Profile Support for "My Associations" Section

### DIFF
--- a/app/src/androidTest/java/com/swent/assos/ProfileTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/ProfileTest.kt
@@ -3,6 +3,8 @@ package com.swent.assos
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.hasText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.swent.assos.model.data.DataCache
+import com.swent.assos.model.data.User
 import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.screens.ProfileScreen
 import com.swent.assos.ui.screens.Profile
@@ -17,7 +19,20 @@ import org.junit.runner.RunWith
 @HiltAndroidTest
 class ProfileTest : SuperTest() {
 
+  private val profileId = "dxpZJlPsqzWAmBI47qtx3jvGMHX2"
+  private val firstName = "Antoine"
+  private val lastName = "Marchand"
+
   override fun setup() {
+    DataCache.currentUser.value =
+        User(
+            id = profileId,
+            firstName = firstName,
+            lastName = lastName,
+            email = "antoine.marchand@epfl.ch",
+            associations = listOf(Triple("QjAOBhVVcL0P2G1etPgk", "Chef de projet", 1)),
+            sciper = "330249",
+            semester = "GM-BA6")
     super.setup()
     composeTestRule.activity.setContent { Profile(navigationActions = mockNavActions) }
   }
@@ -62,6 +77,34 @@ class ProfileTest : SuperTest() {
           followedAssociationSectionTitle {
             assertIsDisplayed()
             assert(hasText("Associations followed", substring = true, ignoreCase = true))
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun profileDisplaysMyAssociations() {
+    run {
+      ComposeScreen.onComposeScreen<ProfileScreen>(composeTestRule) {
+        step("Check if my associations are displayed") {
+          myAssociationItem {
+            assertIsDisplayed()
+            assert(hasText("Rocket Team", substring = true, ignoreCase = true))
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun profileDisplaysUsername() {
+    run {
+      ComposeScreen.onComposeScreen<ProfileScreen>(composeTestRule) {
+        step("Check if username is displayed") {
+          name {
+            assertIsDisplayed()
+            assert(hasText("$firstName $lastName", substring = true, ignoreCase = true))
           }
         }
       }

--- a/app/src/androidTest/java/com/swent/assos/screens/ProfileScreen.kt
+++ b/app/src/androidTest/java/com/swent/assos/screens/ProfileScreen.kt
@@ -15,7 +15,7 @@ class ProfileScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val contentSection: KNode = child { hasTestTag("ContentSection") }
   val myAssociationSectionTitle: KNode =
       contentSection.child { hasTestTag("MyAssociationSectionTitle") }
-  val myAssociationItem: KNode = child { hasTestTag("MyAssociationItem") }
+  val myAssociationItem: KNode = contentSection.child { hasTestTag("MyAssociationItem") }
   val followedAssociationSectionTitle: KNode =
       contentSection.child { hasTestTag("FollowedAssociationSectionTitle") }
   val followedAssociationItem: KNode = child { hasTestTag("FollowedAssociationItem") }

--- a/app/src/main/java/com/swent/assos/model/view/ProfileViewModel.kt
+++ b/app/src/main/java/com/swent/assos/model/view/ProfileViewModel.kt
@@ -20,9 +20,6 @@ constructor(
     private val dbService: DbService,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
-  /* TODO: Link to dataBase the membership,
-  for now all users are "Balélec" & "The Consulting Society" members */
-  private val _memberAssociationIDs = listOf("1UYICvqVKbImYMNK3Sz3", "5Ala8A5MEmoFe5JGJxJV")
 
   private val _followedAssociations = MutableStateFlow(emptyList<Association>())
   val followedAssociations = _followedAssociations.asStateFlow()
@@ -30,11 +27,20 @@ constructor(
   private val _memberAssociations = MutableStateFlow(emptyList<Association>())
   val memberAssociations = _memberAssociations.asStateFlow()
 
+  private val _firstName = MutableStateFlow("")
+  val firstName = _firstName.asStateFlow()
+
+  private val _lastName = MutableStateFlow("")
+  val lastName = _lastName.asStateFlow()
+
   private var _loading = false
 
   init {
     viewModelScope.launch(ioDispatcher) {
       DataCache.currentUser.collect { currentUser ->
+        _firstName.value = currentUser.firstName
+        _lastName.value = currentUser.lastName
+
         currentUser.following.forEach { id ->
           dbService.getAssociationById(id).let {
             _followedAssociations.value += it
@@ -42,8 +48,8 @@ constructor(
                 _followedAssociations.value.distinct().sortedBy { it.acronym }
           }
         }
-        _memberAssociationIDs.forEach { id ->
-          dbService.getAssociationById(id).let {
+        currentUser.associations.forEach { (assoId, pos, rank) ->
+          dbService.getAssociationById(assoId).let {
             _memberAssociations.value += it
             _memberAssociations.value = _memberAssociations.value.distinct().sortedBy { it.acronym }
           }

--- a/app/src/main/java/com/swent/assos/model/view/ProfileViewModel.kt
+++ b/app/src/main/java/com/swent/assos/model/view/ProfileViewModel.kt
@@ -48,7 +48,7 @@ constructor(
                 _followedAssociations.value.distinct().sortedBy { it.acronym }
           }
         }
-        currentUser.associations.forEach { (assoId, pos, rank) ->
+        currentUser.associations.forEach { (assoId, _, _) ->
           dbService.getAssociationById(assoId).let {
             _memberAssociations.value += it
             _memberAssociations.value = _memberAssociations.value.distinct().sortedBy { it.acronym }

--- a/app/src/main/java/com/swent/assos/ui/screens/Profile.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/Profile.kt
@@ -39,14 +39,13 @@ import com.swent.assos.model.view.ProfileViewModel
 @Composable
 fun Profile(navigationActions: NavigationActions) {
 
-  val firstname = "Maximilien"
-  val surname = "GRIDEL"
-
   val viewModel: ProfileViewModel = hiltViewModel()
   val followedAssociationsList by viewModel.followedAssociations.collectAsState()
   val myAssociations by viewModel.memberAssociations.collectAsState()
+  val firstName by viewModel.firstName.collectAsState()
+  val lastName by viewModel.lastName.collectAsState()
 
-  val completeName = "$firstname $surname"
+  val completeName = "$firstName $lastName"
 
   Scaffold(
       modifier = Modifier.semantics { testTagsAsResourceId = true }.testTag("ProfileScreen"),


### PR DESCRIPTION
## Context

Until now, there was a hard coded list of associations for any users. Now the `ProfileViewModel` fetch the username and the associations the current user manage from the Database.

## Modifications

- `ProfileViewModel` was modified so that after connexion, the name & the `memberAssociations` are stored
- `Profile` was modified so that the profile name is fetched from the Database

## Tests

- `ProfileTest` was modified so that the current profile is modified
- `ProfileScreen` was adapted so that the name field is reachable
