### PR TITLE
Upload image from the gallery (creation event)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,6 @@ android {
 }
 
 dependencies {
-
   implementation("androidx.core:core-ktx:1.12.0")
   implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
   implementation("androidx.activity:activity-compose:1.8.2")
@@ -139,6 +138,10 @@ dependencies {
   implementation("sh.calvin.reorderable:reorderable:1.5.2")
   implementation("com.maxkeppeler.sheets-compose-dialogs:core:1.1.1")
   implementation("com.maxkeppeler.sheets-compose-dialogs:date-time:1.1.1")
+
+  // Coil
+  implementation("io.coil-kt:coil-compose:2.1.0")
+  implementation(kotlin("reflect"))
 }
 
 tasks.register("jacocoTestReport", JacocoReport::class) {

--- a/app/src/androidTest/java/com/swent/assos/screens/AssoDetailsScreen.kt
+++ b/app/src/androidTest/java/com/swent/assos/screens/AssoDetailsScreen.kt
@@ -14,4 +14,6 @@ class AssoDetailsScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val title: KNode = header.child { hasTestTag("Title") }
   val followButton: KNode = header.child { hasTestTag("FollowButton") }
   val textFollowButton: KNode = followButton.child { hasTestTag("TextFollowButton") }
+
+  val content: KNode = onNode { hasTestTag("Content") }
 }

--- a/app/src/androidTest/java/com/swent/assos/screens/ManageAssoScreen.kt
+++ b/app/src/androidTest/java/com/swent/assos/screens/ManageAssoScreen.kt
@@ -9,11 +9,13 @@ class ManageAssoScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
         semanticsProvider = semanticsProvider,
         viewBuilderAction = { hasTestTag("ManageAssoScreen") }) {
 
-  val description: KNode = child { hasTestTag("DescriptionField") }
-  val editDescriptionButton: KNode = child { hasTestTag("EditDescriptionButton") }
-  val addEventButton: KNode = child { hasTestTag("AddEventButton") }
-  val addPostButton: KNode = child { hasTestTag("AddPostButton") }
-  val newsItem: KNode = child { hasTestTag("NewsItem") }
+  val content: KNode = child { hasTestTag("Content") }
+  val description: KNode = content.child { hasTestTag("DescriptionField") }
+  val editDescriptionButton: KNode = content.child { hasTestTag("EditDescriptionButton") }
+  val addEventButton: KNode = content.child { hasTestTag("AddEventButton") }
+  val addPostButton: KNode = content.child { hasTestTag("AddPostButton") }
+  val newsItem: KNode = content.child { hasTestTag("NewsItem") }
+
   val topBar: KNode = child { hasTestTag("Header") }
   val goBackButton: KNode = topBar.child { hasTestTag("GoBackButton") }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <application
-   
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
 
+    <application
         android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -19,7 +20,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Assos">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/swent/assos/model/data/Event.kt
+++ b/app/src/main/java/com/swent/assos/model/data/Event.kt
@@ -1,5 +1,6 @@
 package com.swent.assos.model.data
 
+import android.net.Uri
 import com.google.firebase.firestore.DocumentSnapshot
 import java.time.LocalDateTime
 
@@ -7,7 +8,7 @@ data class Event(
     val id: String,
     val title: String = "",
     var associationId: String = "",
-    val image: String = "",
+    var image: Uri = Uri.EMPTY,
     val description: String = "",
     var startTime: LocalDateTime? = null,
     var endTime: LocalDateTime? = null,

--- a/app/src/main/java/com/swent/assos/model/service/StorageService.kt
+++ b/app/src/main/java/com/swent/assos/model/service/StorageService.kt
@@ -1,11 +1,33 @@
 package com.swent.assos.model.service
 
 import android.net.Uri
+import java.lang.Exception
 
 interface StorageService {
-  suspend fun uploadFile(uri: Uri, ref: String): String
+  suspend fun uploadFile(
+      uri: Uri,
+      ref: String,
+      onSuccess: (Uri) -> Unit,
+      onError: (Exception) -> Unit
+  )
 
-  suspend fun uploadFiles(uris: List<Uri>, ref: String): List<String> {
-    return uris.map { uploadFile(it, ref) }
+  suspend fun uploadFiles(
+      uris: List<Uri>,
+      ref: String,
+      onSuccess: (List<Uri>) -> Unit,
+      onError: (List<Exception>) -> Unit
+  ) {
+    val urls = mutableListOf<Uri>()
+    val errors = mutableListOf<Exception>()
+
+    uris.forEach { uri ->
+      uploadFile(uri, ref, { url -> urls.add(url) }, { error -> errors.add(error) })
+    }
+
+    if (errors.isEmpty()) {
+      onSuccess(urls)
+    } else {
+      onError(errors)
+    }
   }
 }

--- a/app/src/main/java/com/swent/assos/model/service/impl/DbServiceImpl.kt
+++ b/app/src/main/java/com/swent/assos/model/service/impl/DbServiceImpl.kt
@@ -1,7 +1,6 @@
 package com.swent.assos.model.service.impl
 
 import android.net.Uri
-import android.util.Log
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot

--- a/app/src/main/java/com/swent/assos/model/service/impl/DbServiceImpl.kt
+++ b/app/src/main/java/com/swent/assos/model/service/impl/DbServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.swent.assos.model.service.impl
 
+import android.net.Uri
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
@@ -166,7 +167,7 @@ constructor(
         firestore
             .collection("news")
             .whereEqualTo("associationId", associationId)
-            .orderBy("date", Query.Direction.DESCENDING)
+            .orderBy("createdAt", Query.Direction.DESCENDING)
     val snapshot =
         if (lastDocumentSnapshot == null) {
           query.limit(10).get().await()
@@ -206,7 +207,7 @@ constructor(
           title = it.getString("title") ?: "",
           description = it.getString("description") ?: "",
           associationId = it.getString("associationId") ?: "",
-          image = it.getString("image") ?: "",
+          image = Uri.parse(it.getString("image") ?: ""),
           startTime = timestampToLocalDateTime(it.getTimestamp("startTime")),
           endTime = timestampToLocalDateTime(it.getTimestamp("endTime")),
           fields =
@@ -255,7 +256,7 @@ constructor(
           title = it.getString("title") ?: "",
           description = it.getString("description") ?: "",
           associationId = it.getString("associationId") ?: "",
-          image = it.getString("image") ?: "",
+          image = Uri.parse(it.getString("image") ?: ""),
           startTime = timestampToLocalDateTime(it.getTimestamp("startTime")),
           endTime = timestampToLocalDateTime(it.getTimestamp("endTime")),
           fields =
@@ -288,7 +289,7 @@ constructor(
                 "title" to event.title,
                 "description" to event.description,
                 "associationId" to event.associationId,
-                "image" to event.image,
+                "image" to event.image.toString(),
                 "startTime" to localDateTimeToTimestamp(event.startTime ?: LocalDateTime.now()),
                 "endTime" to localDateTimeToTimestamp(event.endTime ?: LocalDateTime.now()),
                 "fields" to

--- a/app/src/main/java/com/swent/assos/model/service/impl/StorageServiceImpl.kt
+++ b/app/src/main/java/com/swent/assos/model/service/impl/StorageServiceImpl.kt
@@ -4,36 +4,29 @@ import android.net.Uri
 import com.google.firebase.storage.FirebaseStorage
 import com.swent.assos.model.generateUniqueID
 import com.swent.assos.model.service.StorageService
+import java.lang.Exception
 import javax.inject.Inject
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.single
 
 class StorageServiceImpl @Inject constructor(private val storage: FirebaseStorage) :
     StorageService {
   @ExperimentalCoroutinesApi
-  override suspend fun uploadFile(uri: Uri, ref: String): String {
-    val storageRef = storage.getReference(ref + "/" + generateUniqueID())
+  override suspend fun uploadFile(
+      uri: Uri,
+      ref: String,
+      onSuccess: (Uri) -> Unit,
+      onError: (Exception) -> Unit
+  ) {
+    val storageRef =
+        storage.getReference(
+            ref + "/" + generateUniqueID() + uri.toString().substringAfterLast('.', ""))
 
-    return callbackFlow {
-          val uploadTask = storageRef.putFile(uri)
-          val urlDeferred = CompletableDeferred<String>()
+    val uploadTask = storageRef.putFile(uri)
 
-          uploadTask
-              .addOnSuccessListener { taskSnapshot ->
-                taskSnapshot.storage.downloadUrl
-                    .addOnSuccessListener { uri ->
-                      this.trySend(uri.toString()).isSuccess
-                      close()
-                    }
-                    .addOnFailureListener { exception -> close(exception) }
-              }
-              .addOnFailureListener { exception -> close(exception) }
-
-          awaitClose { urlDeferred.cancel() }
-        }
-        .single()
+    uploadTask.addOnSuccessListener { taskSnapshot ->
+      taskSnapshot.storage.downloadUrl
+          .addOnSuccessListener { uri -> onSuccess(uri) }
+          .addOnFailureListener { exception -> onError(exception) }
+    }
   }
 }

--- a/app/src/main/java/com/swent/assos/model/utils.kt
+++ b/app/src/main/java/com/swent/assos/model/utils.kt
@@ -10,6 +10,8 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
+val MIN_LOADED_ITEMS = 8
+
 fun generateQRCodeBitmap(text: String, size: Int): ImageBitmap {
   val bitMatrix: BitMatrix = MultiFormatWriter().encode(text, BarcodeFormat.QR_CODE, size, size)
   val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.RGB_565)

--- a/app/src/main/java/com/swent/assos/model/view/EventViewModel.kt
+++ b/app/src/main/java/com/swent/assos/model/view/EventViewModel.kt
@@ -59,7 +59,8 @@ constructor(
     _fieldType.value = EventFieldType.TEXT
   }
 
-  fun createEvent(event: Event, onSuccess: () -> Unit) {
+  fun createEvent(onSuccess: () -> Unit) {
+    val event = _event.value
     viewModelScope.launch(ioDispatcher) {
       storageService.uploadFile(
           event.image,

--- a/app/src/main/java/com/swent/assos/model/view/ExplorerViewModel.kt
+++ b/app/src/main/java/com/swent/assos/model/view/ExplorerViewModel.kt
@@ -43,6 +43,9 @@ constructor(private val dbService: DbService, private val authService: AuthServi
           it.acronym.contains(query, ignoreCase = true) ||
               it.fullname.contains(query, ignoreCase = true)
         }
+    if (_filteredAssociations.value.size < 8) {
+      loadMoreAssociations()
+    }
   }
 
   fun loadMoreAssociations() {

--- a/app/src/main/java/com/swent/assos/model/view/ExplorerViewModel.kt
+++ b/app/src/main/java/com/swent/assos/model/view/ExplorerViewModel.kt
@@ -2,6 +2,7 @@ package com.swent.assos.model.view
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.swent.assos.model.MIN_LOADED_ITEMS
 import com.swent.assos.model.data.Association
 import com.swent.assos.model.service.AuthService
 import com.swent.assos.model.service.DbService
@@ -43,7 +44,7 @@ constructor(private val dbService: DbService, private val authService: AuthServi
           it.acronym.contains(query, ignoreCase = true) ||
               it.fullname.contains(query, ignoreCase = true)
         }
-    if (_filteredAssociations.value.size < 8) {
+    if (_filteredAssociations.value.size < MIN_LOADED_ITEMS) {
       loadMoreAssociations()
     }
   }

--- a/app/src/main/java/com/swent/assos/ui/components/EventItem.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/EventItem.kt
@@ -1,11 +1,13 @@
 package com.swent.assos.ui.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -13,7 +15,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
 import com.swent.assos.model.data.Event
 import com.swent.assos.model.formatDateTime
 import com.swent.assos.model.navigation.Destinations
@@ -30,6 +34,12 @@ fun EventItem(event: Event, navigationActions: NavigationActions) {
       color = Color(0xFFE0E0E0),
   ) {
     Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Image(
+          painter = rememberAsyncImagePainter(event.image),
+          contentDescription = null,
+          modifier = Modifier.size(200.dp),
+          contentScale = ContentScale.Crop,
+      )
       Text(text = event.title, style = MaterialTheme.typography.titleMedium)
       Spacer(modifier = Modifier.height(8.dp))
       Text(text = event.description)

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/AssoDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/AssoDetails.kt
@@ -110,7 +110,7 @@ fun AssoDetails(assoId: String, navigationActions: NavigationActions) {
             currentUser = currentUser,
             viewModel = viewModel)
       }) { paddingValues ->
-        LazyColumn(modifier = Modifier.padding(paddingValues)) {
+        LazyColumn(modifier = Modifier.padding(paddingValues).testTag("Content")) {
           item {
             Image(
                 painter = painterResource(id = R.drawable.ic_launcher_foreground),

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/AssoDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/AssoDetails.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -110,72 +110,72 @@ fun AssoDetails(assoId: String, navigationActions: NavigationActions) {
             currentUser = currentUser,
             viewModel = viewModel)
       }) { paddingValues ->
-        Column(modifier = Modifier.padding(paddingValues)) {
-          Image(
-              painter = painterResource(id = R.drawable.ic_launcher_foreground),
-              contentDescription = null,
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .align(Alignment.CenterHorizontally)
-                      .padding(10.dp)
-                      .height(200.dp)
-                      .background(Color.Gray, shape = RoundedCornerShape(20.dp)),
-              contentScale = ContentScale.Crop,
-              alignment = Alignment.Center)
+        LazyColumn(modifier = Modifier.padding(paddingValues)) {
+          item {
+            Image(
+                painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                contentDescription = null,
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(10.dp)
+                        .height(200.dp)
+                        .background(Color.Gray, shape = RoundedCornerShape(20.dp)),
+                contentScale = ContentScale.Crop,
+                alignment = Alignment.Center)
 
-          Text(
-              text = association.description,
-              style = MaterialTheme.typography.bodyMedium,
-              modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 0.dp))
-
-          Text(
-              text = "Upcoming Events",
-              style = MaterialTheme.typography.headlineMedium,
-              fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-              fontWeight = FontWeight.Bold,
-              modifier = Modifier.padding(horizontal = 16.dp, vertical = 0.dp))
-
-          if (events.isNotEmpty()) {
-            LazyRow(
-                state = listStateEvents,
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
-                  items(events) {
-                    EventItem(it, navigationActions)
-                    Spacer(modifier = Modifier.width(8.dp))
-                  }
-                }
-          } else {
             Text(
-                text = "No upcoming events",
+                text = association.description,
                 style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 0.dp))
+
+            Text(
+                text = "Upcoming Events",
+                style = MaterialTheme.typography.headlineMedium,
                 fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-                fontWeight = FontWeight.Medium,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
-          }
-          Text(
-              text = "Latest Posts",
-              style = MaterialTheme.typography.headlineMedium,
-              fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-              fontWeight = FontWeight.Bold,
-              modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 0.dp))
 
-          if (news.isNotEmpty()) {
-            LazyRow(
-                state = listStateNews,
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
-                  items(news) {
-                    NewsItem(it, navigationActions)
-                    Spacer(modifier = Modifier.width(8.dp))
+            if (events.isNotEmpty()) {
+              LazyRow(
+                  state = listStateEvents,
+                  contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
+                    items(events) {
+                      EventItem(it, navigationActions)
+                      Spacer(modifier = Modifier.width(8.dp))
+                    }
                   }
-                }
-          } else {
+            } else {
+              Text(
+                  text = "No upcoming events",
+                  style = MaterialTheme.typography.bodyMedium,
+                  fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+                  fontWeight = FontWeight.Medium,
+                  modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+            }
             Text(
-                text = "No latest posts",
-                style = MaterialTheme.typography.bodyMedium,
+                text = "Latest Posts",
+                style = MaterialTheme.typography.headlineMedium,
+                fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+                fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+
+            if (news.isNotEmpty()) {
+              LazyRow(
+                  state = listStateNews,
+                  contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
+                    items(news) {
+                      NewsItem(it, navigationActions)
+                      Spacer(modifier = Modifier.width(8.dp))
+                    }
+                  }
+            } else {
+              Text(
+                  text = "No latest posts",
+                  style = MaterialTheme.typography.bodyMedium,
+                  modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+            }
+            Spacer(modifier = Modifier.height(20.dp))
           }
-          Spacer(modifier = Modifier.height(20.dp))
-          CustomFAB(onClick = {})
         }
       }
 }

--- a/app/src/main/java/com/swent/assos/ui/screens/calendar/Event.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/calendar/Event.kt
@@ -101,7 +101,8 @@ fun Event(
             measureables.map { measurable ->
               val event = measurable.parentData as Event
               val eventDurationMinutes = ChronoUnit.MINUTES.between(event.startTime, event.endTime)
-              val eventHeight = max(0, ((eventDurationMinutes / 60f) * hourHeight.toPx()).roundToInt())
+              val eventHeight =
+                  max(0, ((eventDurationMinutes / 60f) * hourHeight.toPx()).roundToInt())
               val placeable =
                   measurable.measure(
                       constraints.copy(

--- a/app/src/main/java/com/swent/assos/ui/screens/calendar/Event.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/calendar/Event.kt
@@ -24,6 +24,7 @@ import com.swent.assos.model.data.Event
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import kotlin.math.max
 import kotlin.math.roundToInt
 
 private val EventTimeFormatter = DateTimeFormatter.ofPattern("h:mm a")
@@ -100,7 +101,7 @@ fun Event(
             measureables.map { measurable ->
               val event = measurable.parentData as Event
               val eventDurationMinutes = ChronoUnit.MINUTES.between(event.startTime, event.endTime)
-              val eventHeight = ((eventDurationMinutes / 60f) * hourHeight.toPx()).roundToInt()
+              val eventHeight = max(0, ((eventDurationMinutes / 60f) * hourHeight.toPx()).roundToInt())
               val placeable =
                   measurable.measure(
                       constraints.copy(

--- a/app/src/main/java/com/swent/assos/ui/screens/manageAsso/CreateEvent.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/manageAsso/CreateEvent.kt
@@ -273,7 +273,7 @@ fun CreateEvent(assoId: String, navigationActions: NavigationActions) {
                             event.startTime != null &&
                             event.endTime != null,
                     onClick = {
-                      viewModel.createEvent( onSuccess = { navigationActions.goBack() })
+                      viewModel.createEvent(onSuccess = { navigationActions.goBack() })
                     }) {
                       Text("Validate event")
                     }

--- a/app/src/main/java/com/swent/assos/ui/screens/manageAsso/CreateEvent.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/manageAsso/CreateEvent.kt
@@ -273,8 +273,7 @@ fun CreateEvent(assoId: String, navigationActions: NavigationActions) {
                             event.startTime != null &&
                             event.endTime != null,
                     onClick = {
-                      viewModel.createEvent(
-                          event = event, onSuccess = { navigationActions.goBack() })
+                      viewModel.createEvent( onSuccess = { navigationActions.goBack() })
                     }) {
                       Text("Validate event")
                     }

--- a/app/src/main/java/com/swent/assos/ui/screens/manageAsso/ManageAssociation.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/manageAsso/ManageAssociation.kt
@@ -3,13 +3,14 @@ package com.swent.assos.ui.screens.manageAsso
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -83,48 +84,52 @@ fun ManageAssociation(assoId: String, navigationActions: NavigationActions) {
       modifier = Modifier.semantics { testTagsAsResourceId = true }.testTag("ManageAssoScreen"),
       topBar = { TopAssoBar(asso = association, navigationActions = navigationActions) }) {
           paddingValues ->
-        Column(
+        LazyColumn(
             modifier = Modifier.padding(paddingValues),
             horizontalAlignment = Alignment.CenterHorizontally) {
-              Text(
-                  text = association.fullname,
-                  style = MaterialTheme.typography.bodyMedium,
-                  modifier =
-                      Modifier.testTag("DescriptionField")
-                          .fillMaxWidth()
-                          .padding(horizontal = 16.dp, vertical = 8.dp))
-              Button(
-                  modifier = Modifier.testTag("EditDescriptionButton"),
-                  onClick = { /* TODO */},
-                  colors = ButtonDefaults.buttonColors(containerColor = Color.Red)) {
-                    Text("Edit description", color = Color.White)
-                  }
-              HeaderWithButton(
-                  header = "Upcoming Events",
-                  buttonText = "Add Event",
-                  onButtonClick = {
-                    navigationActions.navigateTo(Destinations.CREATE_EVENT.route + "/${assoId}")
-                  },
-                  modifierButton = Modifier.testTag("AddEventButton"))
+              item {
+                Text(
+                    text = association.fullname,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier =
+                        Modifier.testTag("DescriptionField")
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp))
+                Button(
+                    modifier = Modifier.testTag("EditDescriptionButton"),
+                    onClick = { /* TODO */},
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.Red)) {
+                      Text("Edit description", color = Color.White)
+                    }
+                HeaderWithButton(
+                    header = "Upcoming Events",
+                    buttonText = "Add Event",
+                    onButtonClick = {
+                      navigationActions.navigateTo(Destinations.CREATE_EVENT.route + "/${assoId}")
+                    },
+                    modifierButton = Modifier.testTag("AddEventButton"))
 
-              LazyRow(contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
-                items(events) {
-                  EventItem(it, navigationActions)
-                  Spacer(modifier = Modifier.width(8.dp))
+                LazyRow(contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
+                  items(events) {
+                    EventItem(it, navigationActions)
+                    Spacer(modifier = Modifier.width(8.dp))
+                  }
                 }
-              }
-              HeaderWithButton(
-                  header = "Latest Posts",
-                  buttonText = "Add Post",
-                  onButtonClick = {
-                    navigationActions.navigateTo(Destinations.CREATE_NEWS.route + "/${assoId}")
-                  },
-                  modifierButton = Modifier.testTag("AddPostButton"))
-              LazyRow(contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
-                items(news) {
-                  NewsItem(it, navigationActions)
-                  Spacer(modifier = Modifier.width(8.dp))
+                HeaderWithButton(
+                    header = "Latest Posts",
+                    buttonText = "Add Post",
+                    onButtonClick = {
+                      navigationActions.navigateTo(Destinations.CREATE_NEWS.route + "/${assoId}")
+                    },
+                    modifierButton = Modifier.testTag("AddPostButton"))
+                LazyRow(contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)) {
+                  items(news) {
+                    NewsItem(it, navigationActions)
+                    Spacer(modifier = Modifier.width(8.dp))
+                  }
                 }
+
+                Spacer(modifier = Modifier.height(20.dp))
               }
             }
       }

--- a/app/src/main/java/com/swent/assos/ui/screens/manageAsso/ManageAssociation.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/manageAsso/ManageAssociation.kt
@@ -85,7 +85,7 @@ fun ManageAssociation(assoId: String, navigationActions: NavigationActions) {
       topBar = { TopAssoBar(asso = association, navigationActions = navigationActions) }) {
           paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier.padding(paddingValues).testTag("Content"),
             horizontalAlignment = Alignment.CenterHorizontally) {
               item {
                 Text(

--- a/app/src/test/java/com/swent/assos/StorageServiceTest.kt
+++ b/app/src/test/java/com/swent/assos/StorageServiceTest.kt
@@ -51,18 +51,24 @@ class StorageServiceTest {
           downloadUrlTask
         }
     every { downloadUrlTask.addOnFailureListener(any()) } returns downloadUrlTask
-    every { mockUri.toString() } returns "https://test.com/file"
+    every { mockUri.toString() } returns "https://test.com/file.jpg"
   }
 
   @Test
   fun uploadFilesTest() = runTest {
-    val uri1 = Uri.parse("file://dummy/path1")
-    val uri2 = Uri.parse("file://dummy/path2")
+    val uri1 = Uri.parse("file://dummy/path1.jpg")
+    val uri2 = Uri.parse("file://dummy/path2.jpg")
     val ref = "testRef"
 
     storageService = StorageServiceImpl(firebaseStorage)
-    val result = storageService.uploadFiles(listOf(uri1, uri2), ref)
-
-    assertEquals(listOf("https://test.com/file", "https://test.com/file"), result)
+    storageService.uploadFiles(
+        listOf(uri1, uri2),
+        ref,
+        {
+          assertEquals(2, it.size)
+          assertEquals("https://test.com/file.jpg", it[0].toString())
+          assertEquals("https://test.com/file.jpg", it[1].toString())
+        },
+        { fail("Should not fail") })
   }
 }


### PR DESCRIPTION
# Upload image from the gallery (creation event)

## Overview

Following up on pull request #78, I have implemented a feature to upload an image from the phone gallery to Firebase Storage, which will be used in the event creation process. This implementation will serve as a reference model for incorporating similar functionality elsewhere in the application.

## Modifications

- Updated the `StorageService` and `StorageServiceImpl` classes to accept `onSuccess` and `onError` functions as parameters for their methods.
- Modified the image input process in `CreateEvent.kt` by introducing a new launcher to access the gallery.
- Altered the event creation process to invoke the `uploadFile` method and subsequently set the event's image with the download URL retrieved from Firebase Storage.
- Enabled the display of the event image across various association screens within the event card.
- Added necessary permissions to `AndroidManifest.xml`.

## Testing

- Modified the tests to accommodate the `uploadFiles` method.

## Dependency Requirements

- Integrated `Coil` dependencies to facilitate the display of images from `Uri`.
