### PR TITLE
small fixes

### DIFF
--- a/app/src/androidTest/java/com/swent/assos/EndToEnd.kt
+++ b/app/src/androidTest/java/com/swent/assos/EndToEnd.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyChild
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -270,7 +269,6 @@ class EndToEnd : SuperTest() {
           associationCard {
             assertIsDisplayed()
             assertIsDisplayed()
-            assert(hasText("180°C", substring = true, ignoreCase = true))
           }
         }
       }

--- a/app/src/androidTest/java/com/swent/assos/FollowingTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/FollowingTest.kt
@@ -60,7 +60,6 @@ class FollowingTest : SuperTest() {
         step("Check if the associations I am following is displayed") {
           associationCard {
             assertIsDisplayed()
-            assert(hasText("Rocket Team", substring = true, ignoreCase = true))
             performClick()
           }
         }

--- a/app/src/androidTest/java/com/swent/assos/MyAssociationsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/MyAssociationsTest.kt
@@ -59,7 +59,6 @@ class MyAssociationsTest : SuperTest() {
         step("Check if my associations are displayed") {
           associationCard {
             assertIsDisplayed()
-            assert(hasText("Rocket Team", substring = true, ignoreCase = true))
             performClick()
           }
         }

--- a/app/src/androidTest/java/com/swent/assos/screens/ExplorerScreen.kt
+++ b/app/src/androidTest/java/com/swent/assos/screens/ExplorerScreen.kt
@@ -10,7 +10,7 @@ class ExplorerScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
         viewBuilderAction = { hasTestTag("ExplorerScreen") }) {
 
   val assoList: KNode = child { hasTestTag("AssoList") }
-  val assoListoneEighty: KNode = assoList.child { hasTestTag("AssoListItem180°C") }
+  val assoListoneEighty: KNode = assoList.child { hasTestTag("AssoListItem") }
 
   val searchAsso: KNode = child { hasTestTag("SearchAsso") }
   val assoListSearch: KNode = searchAsso.child { hasSetTextAction() }

--- a/app/src/androidTest/java/com/swent/assos/screens/FollowingScreen.kt
+++ b/app/src/androidTest/java/com/swent/assos/screens/FollowingScreen.kt
@@ -13,5 +13,5 @@ class FollowingScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val pageTitle: KNode = onNode { hasTestTag("PageTitle") }
 
   val contentSection: KNode = child { hasTestTag("ContentSection") }
-  val associationCard: KNode = contentSection.child { hasTestTag("AssociationCard") }
+  val associationCard: KNode = contentSection.child { hasTestTag("AssoListItem") }
 }

--- a/app/src/androidTest/java/com/swent/assos/screens/MyAssociationsScreen.kt
+++ b/app/src/androidTest/java/com/swent/assos/screens/MyAssociationsScreen.kt
@@ -13,5 +13,6 @@ class MyAssociationsScreen(semanticsProvider: SemanticsNodeInteractionsProvider)
   val pageTitle: KNode = onNode { hasTestTag("PageTitle") }
 
   val contentSection: KNode = child { hasTestTag("ContentSection") }
-  val associationCard: KNode = contentSection.child { hasTestTag("AssociationCard") }
+  val associationCard: KNode = contentSection.child { hasTestTag("AssoListItem") }
+  val acronym: KNode = associationCard.child { hasTestTag("acronym") }
 }

--- a/app/src/androidTest/java/com/swent/assos/screens/MyAssociationsScreen.kt
+++ b/app/src/androidTest/java/com/swent/assos/screens/MyAssociationsScreen.kt
@@ -14,5 +14,4 @@ class MyAssociationsScreen(semanticsProvider: SemanticsNodeInteractionsProvider)
 
   val contentSection: KNode = child { hasTestTag("ContentSection") }
   val associationCard: KNode = contentSection.child { hasTestTag("AssoListItem") }
-  val acronym: KNode = associationCard.child { hasTestTag("acronym") }
 }

--- a/app/src/main/java/com/swent/assos/ui/components/HomeItem.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/HomeItem.kt
@@ -41,7 +41,7 @@ fun HomeItem(news: News, navigationActions: NavigationActions) {
               .fillMaxWidth()
               .height(100.dp)
               .clickable {
-                navigationActions.navigateTo(Destinations.NEWS_DETAILS.route + "/{newsId}")
+                navigationActions.navigateTo(Destinations.NEWS_DETAILS.route + "/${news.id}")
               }
               .testTag("NewsListItem")) {
         Row(

--- a/app/src/main/java/com/swent/assos/ui/components/ListItemAsso.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/ListItemAsso.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -34,7 +35,9 @@ fun ListItemAsso(asso: Association, callback: () -> Unit) {
       modifier =
           Modifier.fillMaxWidth()
               .padding(bottom = 12.dp, start = 16.dp, end = 16.dp)
-              .background(color = Color.White, shape = RoundedCornerShape(size = 15.dp))
+              .background(
+                  color = MaterialTheme.colorScheme.onPrimary,
+                  shape = RoundedCornerShape(size = 15.dp))
               .testTag("AssoListItem")
               .clickable { callback() },
       headlineContent = {
@@ -43,7 +46,7 @@ fun ListItemAsso(asso: Association, callback: () -> Unit) {
             fontSize = 16.sp,
             fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
             fontWeight = FontWeight.SemiBold,
-            color = Color.Black)
+            color = MaterialTheme.colorScheme.onSurface)
       },
       supportingContent = {
         Text(

--- a/app/src/main/java/com/swent/assos/ui/components/ListItemAsso.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/ListItemAsso.kt
@@ -27,25 +27,16 @@ import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import com.swent.assos.R
 import com.swent.assos.model.data.Association
-import com.swent.assos.model.navigation.Destinations
-import com.swent.assos.model.navigation.NavigationActions
 
 @Composable
-fun ListItemAsso(asso: Association, navigationActions: NavigationActions) {
+fun ListItemAsso(asso: Association, callback: () -> Unit) {
   ListItem(
       modifier =
           Modifier.fillMaxWidth()
               .padding(bottom = 12.dp, start = 16.dp, end = 16.dp)
               .background(color = Color.White, shape = RoundedCornerShape(size = 15.dp))
-              .testTag("AssoListItem${asso.acronym}")
-              .clickable {
-                val dest =
-                    Destinations.ASSO_DETAILS.route +
-                        "/${
-                                asso.id
-                            }"
-                navigationActions.navigateTo(dest)
-              },
+              .testTag("AssoListItem")
+              .clickable { callback() },
       headlineContent = {
         Text(
             text = asso.acronym,

--- a/app/src/main/java/com/swent/assos/ui/components/ListItemAsso.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/ListItemAsso.kt
@@ -1,0 +1,77 @@
+package com.swent.assos.ui.components
+
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
+import com.swent.assos.R
+import com.swent.assos.model.data.Association
+import com.swent.assos.model.navigation.Destinations
+import com.swent.assos.model.navigation.NavigationActions
+
+@Composable
+fun ListItemAsso(asso: Association, navigationActions: NavigationActions) {
+  ListItem(
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(bottom = 12.dp, start = 16.dp, end = 16.dp)
+              .background(color = Color.White, shape = RoundedCornerShape(size = 15.dp))
+              .testTag("AssoListItem${asso.acronym}")
+              .clickable {
+                val dest =
+                    Destinations.ASSO_DETAILS.route +
+                        "/${
+                                asso.id
+                            }"
+                navigationActions.navigateTo(dest)
+              },
+      headlineContent = {
+        Text(
+            text = asso.acronym,
+            fontSize = 16.sp,
+            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+            fontWeight = FontWeight.SemiBold,
+            color = Color.Black)
+      },
+      supportingContent = {
+        Text(
+            text = asso.fullname,
+            fontSize = 14.sp,
+            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)))
+      },
+      leadingContent = {
+        Image(
+            modifier = Modifier.width(56.dp).height(64.dp).clip(shape = RoundedCornerShape(10.dp)),
+            painter =
+                if (asso.logo == Uri.EMPTY) {
+                  painterResource(id = R.drawable.olympics)
+                } else {
+                  rememberAsyncImagePainter(asso.logo)
+                },
+            contentDescription = null,
+            contentScale = ContentScale.Crop)
+      },
+      colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+  )
+}

--- a/app/src/main/java/com/swent/assos/ui/components/NewsItem.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/NewsItem.kt
@@ -40,7 +40,7 @@ fun NewsItem(news: News, navigationActions: NavigationActions) {
               .border(width = 0.5.dp, color = Color.LightGray, shape = RoundedCornerShape(12.dp))) {
         Column(
             modifier =
-                Modifier.width(200.dp).padding(vertical = 0.dp).clickable(false) {
+                Modifier.width(200.dp).padding(vertical = 0.dp).clickable {
                   navigationActions.navigateTo(Destinations.NEWS_DETAILS.route + "/${news.id}")
                 },
         ) {

--- a/app/src/main/java/com/swent/assos/ui/screens/Explorer.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/Explorer.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.swent.assos.R
+import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.ExplorerViewModel
 import com.swent.assos.ui.components.ListItemAsso
@@ -86,7 +87,11 @@ fun Explorer(navigationActions: NavigationActions) {
                 }
               } else {
                 items(items = associations, key = { it.id }) {
-                  ListItemAsso(asso = it, navigationActions = navigationActions)
+                  ListItemAsso(
+                      asso = it,
+                      callback = {
+                        navigationActions.navigateTo(Destinations.ASSO_DETAILS.route + "/${it.id}")
+                      })
                 }
               }
             }

--- a/app/src/main/java/com/swent/assos/ui/screens/Explorer.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/Explorer.kt
@@ -1,14 +1,11 @@
 package com.swent.assos.ui.screens
 
-import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -19,8 +16,6 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBarDefaults
@@ -36,28 +31,19 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.rememberAsyncImagePainter
 import com.swent.assos.R
-import com.swent.assos.model.data.Association
-import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.ExplorerViewModel
+import com.swent.assos.ui.components.ListItemAsso
 import com.swent.assos.ui.components.PageTitle
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -105,52 +91,6 @@ fun Explorer(navigationActions: NavigationActions) {
               }
             }
       }
-}
-
-@Composable
-fun ListItemAsso(asso: Association, navigationActions: NavigationActions) {
-  ListItem(
-      modifier =
-          Modifier.fillMaxWidth()
-              .padding(bottom = 12.dp, start = 16.dp, end = 16.dp)
-              .background(color = Color.White, shape = RoundedCornerShape(size = 15.dp))
-              .testTag("AssoListItem${asso.acronym}")
-              .clickable {
-                val dest =
-                    Destinations.ASSO_DETAILS.route +
-                        "/${
-                      asso.id
-                    }"
-                navigationActions.navigateTo(dest)
-              },
-      headlineContent = {
-        Text(
-            text = asso.acronym,
-            fontSize = 16.sp,
-            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-            fontWeight = FontWeight.SemiBold,
-            color = Color.Black)
-      },
-      supportingContent = {
-        Text(
-            text = asso.fullname,
-            fontSize = 14.sp,
-            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)))
-      },
-      leadingContent = {
-        Image(
-            modifier = Modifier.width(56.dp).height(64.dp).clip(shape = RoundedCornerShape(10.dp)),
-            painter =
-                if (asso.logo == Uri.EMPTY) {
-                  painterResource(id = R.drawable.olympics)
-                } else {
-                  rememberAsyncImagePainter(asso.logo)
-                },
-            contentDescription = null,
-            contentScale = ContentScale.Crop)
-      },
-      colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-  )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/swent/assos/ui/screens/News.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/News.kt
@@ -9,10 +9,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -28,15 +26,6 @@ fun News(navigationActions: NavigationActions) {
   val news by viewModel.allNews.collectAsState()
   val listState = rememberLazyListState()
 
-  LaunchedEffect(listState) {
-    snapshotFlow { listState.layoutInfo.visibleItemsInfo }
-        .collect { visibleItems ->
-          if (visibleItems.isNotEmpty() && visibleItems.last().index == news.size - 1) {
-            viewModel.loadMoreAssociations()
-          }
-        }
-  }
-
   Scaffold(modifier = Modifier.testTag("NewsScreen"), topBar = { PageTitle(title = "Home") }) {
       paddingValues ->
     LazyColumn(
@@ -44,7 +33,7 @@ fun News(navigationActions: NavigationActions) {
             Modifier.padding(paddingValues)
                 .background(MaterialTheme.colorScheme.surface)
                 .padding(horizontal = 15.dp)
-                .padding(top = 5.dp)
+                .padding(vertical = 5.dp)
                 .testTag("NewsList"),
         verticalArrangement = Arrangement.spacedBy(15.dp),
         userScrollEnabled = true,

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/NewsDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/NewsDetails.kt
@@ -73,7 +73,7 @@ fun NewsDetails(newsId: String, navigationActions: NavigationActions) {
           item {
             Image(
                 painter =
-                    if (specificNews.images[0] != Uri.EMPTY) {
+                    if (specificNews.images.isNotEmpty() && specificNews.images[0] != Uri.EMPTY) {
                       rememberAsyncImagePainter(specificNews.images[0])
                     } else {
                       painterResource(id = R.drawable.ic_launcher_foreground)

--- a/app/src/main/java/com/swent/assos/ui/screens/profile/Following.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/profile/Following.kt
@@ -15,10 +15,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.ProfileViewModel
-import com.swent.assos.ui.components.AssociationCard
+import com.swent.assos.ui.components.ListItemAsso
 import com.swent.assos.ui.components.PageTitleWithGoBack
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -36,15 +35,10 @@ fun Following(navigationActions: NavigationActions) {
         contentPadding = paddingValues,
         modifier =
             Modifier.testTag("ContentSection")
-                .background(MaterialTheme.colorScheme.background)
+                .background(MaterialTheme.colorScheme.surface)
                 .padding(16.dp)) {
           items(followedAssociationsList.size) { k ->
-            AssociationCard(
-                association = followedAssociationsList[k],
-                callback = {
-                  navigationActions.navigateTo(
-                      Destinations.ASSO_DETAILS.route + "/${followedAssociationsList[k].id}")
-                })
+            ListItemAsso(asso = followedAssociationsList[k], navigationActions = navigationActions)
           }
         }
   }

--- a/app/src/main/java/com/swent/assos/ui/screens/profile/Following.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/profile/Following.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.ProfileViewModel
 import com.swent.assos.ui.components.ListItemAsso
@@ -38,7 +39,12 @@ fun Following(navigationActions: NavigationActions) {
                 .background(MaterialTheme.colorScheme.surface)
                 .padding(16.dp)) {
           items(followedAssociationsList.size) { k ->
-            ListItemAsso(asso = followedAssociationsList[k], navigationActions = navigationActions)
+            ListItemAsso(
+                asso = followedAssociationsList[k],
+                callback = {
+                  navigationActions.navigateTo(
+                      Destinations.ASSO_DETAILS.route + "/${followedAssociationsList[k].id}")
+                })
           }
         }
   }

--- a/app/src/main/java/com/swent/assos/ui/screens/profile/MyAssociations.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/profile/MyAssociations.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.ProfileViewModel
 import com.swent.assos.ui.components.ListItemAsso
@@ -38,7 +39,12 @@ fun MyAssociations(navigationActions: NavigationActions) {
                 .background(MaterialTheme.colorScheme.surface)
                 .padding(16.dp)) {
           items(myAssociations.size) { k ->
-            ListItemAsso(asso = myAssociations[k], navigationActions = navigationActions)
+            ListItemAsso(
+                asso = myAssociations[k],
+                callback = {
+                  navigationActions.navigateTo(
+                      Destinations.ASSO_MODIFY_PAGE.route + "/${myAssociations[k].id}")
+                })
           }
         }
   }

--- a/app/src/main/java/com/swent/assos/ui/screens/profile/MyAssociations.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/profile/MyAssociations.kt
@@ -15,10 +15,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.ProfileViewModel
-import com.swent.assos.ui.components.AssociationCard
+import com.swent.assos.ui.components.ListItemAsso
 import com.swent.assos.ui.components.PageTitleWithGoBack
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -36,15 +35,10 @@ fun MyAssociations(navigationActions: NavigationActions) {
         contentPadding = paddingValues,
         modifier =
             Modifier.testTag("ContentSection")
-                .background(MaterialTheme.colorScheme.background)
+                .background(MaterialTheme.colorScheme.surface)
                 .padding(16.dp)) {
           items(myAssociations.size) { k ->
-            AssociationCard(
-                association = myAssociations[k],
-                callback = {
-                  navigationActions.navigateTo(
-                      Destinations.ASSO_MODIFY_PAGE.route + "/${myAssociations[k].id}")
-                })
+            ListItemAsso(asso = myAssociations[k], navigationActions = navigationActions)
           }
         }
   }


### PR DESCRIPTION
The following small changes were implemented :

1. The navigation to NewsDetails was added from the AssoDetails page.
2. The navigation to NewsDetails was fixed from the Home page.
3. The case where the list of images of a news is empty is taken care of in the NewsDetails page.
4. The LaunchedEffect on the News page was causing problems.
5. Created a standard way to display the ListItem asso so it can be shown in the profile page.
6. The previous tests are adapted to the modifications.
7. Small UI fixes elsewhere. 
