### PR TITLE
Qr Code Patch

### DIFF
--- a/app/src/main/java/com/swent/assos/model/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/swent/assos/model/navigation/NavigationGraph.kt
@@ -28,7 +28,6 @@ import com.swent.assos.ui.screens.profile.MyAssociations
 import com.swent.assos.ui.screens.profile.NotificationSettings
 import com.swent.assos.ui.screens.profile.Settings
 import com.swent.assos.ui.screens.ticket.CreateTicket
-import com.swent.assos.ui.screens.ticket.MyTickets
 import com.swent.assos.ui.screens.ticket.ScanTicket
 import com.swent.assos.ui.screens.ticket.TicketDetails
 

--- a/app/src/main/java/com/swent/assos/model/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/swent/assos/model/navigation/NavigationGraph.kt
@@ -56,9 +56,6 @@ fun NavigationGraph(navController: NavHostController = rememberNavController()) 
         composable(Destinations.HOME.route) {
           HomeNavigation(navigationActions = navigationActions)
         }
-        composable(Destinations.MY_TICKETS.route) {
-          MyTickets(navigationActions = navigationActions)
-        }
         composable(Destinations.TICKET_DETAILS.route + "/{eventId}") { backStackEntry ->
           TicketDetails(
               eventId = backStackEntry.arguments?.getString("eventId").toString(),
@@ -141,7 +138,6 @@ fun NavigationGraph(navController: NavHostController = rememberNavController()) 
 enum class Destinations(val route: String) {
   LOGIN("Login"),
   HOME("Home"),
-  MY_TICKETS("MyTickets"),
   ASSO_DETAILS("AssoDetails"),
   SIGN_UP("SignUp"),
   CREATE_NEWS("CreateNews"),

--- a/app/src/main/java/com/swent/assos/ui/screens/ticket/MyTickets.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/ticket/MyTickets.kt
@@ -36,12 +36,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.rememberAsyncImagePainter
 import com.swent.assos.NFCReader
+import com.swent.assos.R
 import com.swent.assos.model.data.Ticket
 import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
@@ -78,6 +81,14 @@ fun MyTickets(navigationActions: NavigationActions) {
             horizontalAlignment = Alignment.CenterHorizontally,
             userScrollEnabled = true,
         ) {
+          if (myTickets.isEmpty()) {
+            item {
+              Text(
+                  text = stringResource(R.string.NoResult),
+                  textAlign = TextAlign.Center,
+                  color = MaterialTheme.colorScheme.onBackground)
+            }
+          }
           items(items = myTickets, key = { it.id }) {
             TicketItem(ticket = it, navigationActions = navigationActions)
           }

--- a/app/src/main/java/com/swent/assos/ui/screens/ticket/ScanTicket.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/ticket/ScanTicket.kt
@@ -47,7 +47,6 @@ import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.qr_code.ScannerAnalyzer
 import com.swent.assos.model.qr_code.ScannerViewState
 import com.swent.assos.model.view.EventViewModel
-import com.swent.assos.model.view.TicketViewModel
 import com.swent.assos.ui.components.PageTitleWithGoBack
 import java.io.File
 import java.text.SimpleDateFormat

--- a/app/src/main/java/com/swent/assos/ui/screens/ticket/ScanTicket.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/ticket/ScanTicket.kt
@@ -157,7 +157,7 @@ fun CameraScreen(navigationActions: NavigationActions) {
   val lifecycleOwner = LocalLifecycleOwner.current
   val imageCapture = remember { ImageCapture.Builder().build() }
   val eventViewModel: EventViewModel = hiltViewModel()
-  val ticketViewModel: TicketViewModel = hiltViewModel()
+  var scanSucceeded = false
 
   val cameraPermissionLauncher =
       rememberLauncherForActivityResult(
@@ -187,22 +187,26 @@ fun CameraScreen(navigationActions: NavigationActions) {
             when (state) {
               is ScannerViewState.Success -> {
                 Log.d("CameraPreview", "Barcode scanned: $result")
-                eventViewModel.createTicket(
-                    email = DataCache.currentUser.value.email,
-                    eventId = result,
-                    onSuccess = {
-                      CoroutineScope(Dispatchers.Main).launch {
-                        Toast.makeText(context, "Ticket created", Toast.LENGTH_SHORT).show()
-                        navigationActions.goBack()
-                      }
-                    },
-                    onFailure = {
-                      CoroutineScope(Dispatchers.Main).launch {
-                        Toast.makeText(context, "Ticket creation failed", Toast.LENGTH_SHORT).show()
-                        navigationActions.goBack()
-                      }
-                    },
-                    status = ParticipationStatus.Participant)
+                if (!scanSucceeded) {
+                  eventViewModel.createTicket(
+                      email = DataCache.currentUser.value.email,
+                      eventId = result,
+                      onSuccess = {
+                        CoroutineScope(Dispatchers.Main).launch {
+                          Toast.makeText(context, "Ticket created", Toast.LENGTH_SHORT).show()
+                          navigationActions.goBack()
+                        }
+                      },
+                      onFailure = {
+                        CoroutineScope(Dispatchers.Main).launch {
+                          Toast.makeText(context, "Ticket creation failed", Toast.LENGTH_SHORT)
+                              .show()
+                          navigationActions.goBack()
+                        }
+                      },
+                      status = ParticipationStatus.Participant)
+                }
+                scanSucceeded = true
               }
               is ScannerViewState.Error -> {
                 Toast.makeText(context, "Barcode scanning failed, try again", Toast.LENGTH_SHORT)

--- a/app/src/main/java/com/swent/assos/ui/screens/ticket/ScanTicket.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/ticket/ScanTicket.kt
@@ -43,7 +43,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.LifecycleOwner
 import com.swent.assos.model.data.DataCache
 import com.swent.assos.model.data.ParticipationStatus
-import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.qr_code.ScannerAnalyzer
 import com.swent.assos.model.qr_code.ScannerViewState
@@ -194,12 +193,13 @@ fun CameraScreen(navigationActions: NavigationActions) {
                     onSuccess = {
                       CoroutineScope(Dispatchers.Main).launch {
                         Toast.makeText(context, "Ticket created", Toast.LENGTH_SHORT).show()
-                        navigationActions.navigateTo(Destinations.MY_TICKETS)
+                        navigationActions.goBack()
                       }
                     },
                     onFailure = {
                       CoroutineScope(Dispatchers.Main).launch {
                         Toast.makeText(context, "Ticket creation failed", Toast.LENGTH_SHORT).show()
+                        navigationActions.goBack()
                       }
                     },
                     status = ParticipationStatus.Participant)

--- a/app/src/main/java/com/swent/assos/ui/screens/ticket/ScanTicket.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/ticket/ScanTicket.kt
@@ -185,7 +185,6 @@ fun CameraScreen(navigationActions: NavigationActions) {
           onResult = { state, result ->
             when (state) {
               is ScannerViewState.Success -> {
-                Log.d("CameraPreview", "Barcode scanned: $result")
                 if (!scanSucceeded) {
                   eventViewModel.createTicket(
                       email = DataCache.currentUser.value.email,


### PR DESCRIPTION
Here is a very small PR to fix the glitchy behaviour of our QR Code scanning. Previously, when we scanned a QR Code containing a correct eventID, the `goBack` on `navigationActions` was called twice or three times rather than just once. I fixed it with a flag to ensure the callback is only called one and only once