### PR TITLE
fixed a sign up crash

### DIFF
--- a/app/src/androidTest/java/com/swent/assos/SignupTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/SignupTest.kt
@@ -1,7 +1,6 @@
 package com.swent.assos
 
 import androidx.activity.compose.setContent
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -22,11 +21,11 @@ import io.mockk.confirmVerified
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.verify
-import java.lang.Thread.sleep
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.lang.Thread.sleep
 
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
@@ -113,7 +112,7 @@ class SignupTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withComposeSupp
           }
         }
         sleep(1000)
-        verify { mockNavActions.navigateTo(Destinations.HOME) }
+        verify { mockNavActions.navigateTo(Destinations.HOME.route) }
         confirmVerified(mockNavActions)
       }
     }

--- a/app/src/main/java/com/swent/assos/ui/login/SignUpScreen.kt
+++ b/app/src/main/java/com/swent/assos/ui/login/SignUpScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -43,7 +42,6 @@ import com.swent.assos.R
 import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.LoginViewModel
-import org.w3c.dom.Text
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -204,7 +202,7 @@ fun SignUpScreen(navigationActions: NavigationActions) {
                 return@signUp
               } else {
                 try {
-                  navigationActions.navigateTo(Destinations.HOME)
+                  navigationActions.navigateTo(Destinations.HOME.route)
                 } catch (e: Exception) {
                   throw e
                 }


### PR DESCRIPTION
Fixed a sign up crash that occurs when trying to create a user with "test@epfl.ch" as a username. Fixed it by changing the `navigateTo(Destinations.HOME)` to `navigateTo(Destinations.HOME.route)`. We still have to discuss why it is happening with our previous version.