### PR TITLE
implement button and naviation on EventDetails + NewsDetails

### DIFF
--- a/app/src/androidTest/java/com/swent/assos/EventDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/EventDetailsTest.kt
@@ -119,7 +119,7 @@ class EventDetailsTest : SuperTest() {
 
     run {
       ComposeScreen.onComposeScreen<EventDetailsScreen>(composeTestRule) {
-        composeTestRule.waitUntil(timeoutMillis = 5000) {
+        composeTestRule.waitUntil(timeoutMillis = 10000) {
           composeTestRule.onNodeWithText("Add Ticket").isDisplayed()
         }
         step("I want to create a ticket") {
@@ -141,12 +141,14 @@ class EventDetailsTest : SuperTest() {
     run {
       ComposeScreen.onComposeScreen<EventDetailsScreen>(composeTestRule) {
         step("Delete Event") {
-          composeTestRule.waitUntil(10000) { composeTestRule.onNodeWithTag("Button").isDisplayed() }
-          composeTestRule.onNodeWithTag("Button").performClick()
+          composeTestRule.waitUntil(10000) {
+            composeTestRule.onNodeWithTag("DeleteButton").isDisplayed()
+          }
+          composeTestRule.onNodeWithTag("DeleteButton").performClick()
         }
         composeTestRule.waitUntil(10000) { composeTestRule.onNodeWithText("No").isDisplayed() }
         step("cancel deletion") { composeTestRule.onNodeWithText("No").performClick() }
-        step("Delete Event") { composeTestRule.onNodeWithTag("Button").performClick() }
+        step("Delete Event") { composeTestRule.onNodeWithTag("DeleteButton").performClick() }
         step("confirm deletion") { composeTestRule.onNodeWithText("Yes").performClick() }
         step("check if we really delete the event") {
           verify { mockNavActions.goBack() }

--- a/app/src/androidTest/java/com/swent/assos/NavigationTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/NavigationTest.kt
@@ -29,7 +29,7 @@ class NavigationTest : SuperTest() {
     navHostController.navigate(Destinations.SCAN_TICKET.route)
     navHostController.navigate(Destinations.ASSO_DETAILS.route + "/assoId")
     navHostController.navigate(Destinations.EVENT_DETAILS.route + "/eventId" + "/assoId")
-    navHostController.navigate(Destinations.NEWS_DETAILS.route + "/newsId")
+    navHostController.navigate(Destinations.NEWS_DETAILS.route + "/newsId" + "/assoId")
     navHostController.navigate(Destinations.STAFF_MANAGEMENT.route + "/eventId")
     navHostController.navigate(Destinations.APPLICATION_MANAGEMENT.route + "/assoId")
     navHostController.navigate(Destinations.CREATE_NEWS.route + "/assoId")

--- a/app/src/androidTest/java/com/swent/assos/NewsDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/NewsDetailsTest.kt
@@ -11,6 +11,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.swent.assos.model.data.DataCache
 import com.swent.assos.model.data.News
 import com.swent.assos.model.data.User
+import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.serialize
 import com.swent.assos.screens.NewsDetailsScreen
 import com.swent.assos.screens.NewsScreen
@@ -28,7 +29,7 @@ import org.junit.runner.RunWith
 @HiltAndroidTest
 class NewsDetailsTest : SuperTest() {
 
-  val associationID = "GTi6W84Se3DGjfK6Z7MG"
+  val associationID = "3YHxpLIpGyHVT9NAAfEw"
 
   val fakeUser =
       User(
@@ -64,7 +65,27 @@ class NewsDetailsTest : SuperTest() {
         .set(serialize(OtherFakeUser))
     FirebaseFirestore.getInstance().collection("news").document(news.id).set(serNews)
     composeTestRule.activity.setContent {
-      NewsDetails(newsId = news.id, navigationActions = mockNavActions)
+      NewsDetails(newsId = news.id, assoId = associationID, navigationActions = mockNavActions)
+    }
+  }
+
+  @Test
+  fun testButtonToNavigateToAssociationDetailsPage() {
+    run {
+      ComposeScreen.onComposeScreen<NewsDetailsScreen>(composeTestRule) {
+        composeTestRule.waitUntil(
+            condition = { composeTestRule.onNodeWithText("Artiphys").isDisplayed() },
+            timeoutMillis = 10000)
+        step("Click on the button to navigate to the association details page") {
+          composeTestRule.onNodeWithText("Artiphys").performClick()
+        }
+        step("Check if we really navigate to the association details page") {
+          verify {
+            mockNavActions.navigateTo(Destinations.ASSO_DETAILS.route + "/${associationID}")
+          }
+          confirmVerified(mockNavActions)
+        }
+      }
     }
   }
 

--- a/app/src/androidTest/java/com/swent/assos/NewsDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/NewsDetailsTest.kt
@@ -128,11 +128,13 @@ class NewsDetailsTest : SuperTest() {
     run {
       ComposeScreen.onComposeScreen<NewsDetailsScreen>(composeTestRule) {
         step("Delete News") {
-          composeTestRule.waitUntil(10000) { composeTestRule.onNodeWithTag("Button").isDisplayed() }
-          composeTestRule.onNodeWithTag("Button").performClick()
+          composeTestRule.waitUntil(10000) {
+            composeTestRule.onNodeWithTag("DeleteButton").isDisplayed()
+          }
+          composeTestRule.onNodeWithTag("DeleteButton").performClick()
         }
         step("cancel deletion") { composeTestRule.onNodeWithText("No").performClick() }
-        step("Delete News") { composeTestRule.onNodeWithTag("Button").performClick() }
+        step("Delete News") { composeTestRule.onNodeWithTag("DeleteButton").performClick() }
         step("confirm deletion") { composeTestRule.onNodeWithText("Yes").performClick() }
         step("check if we really delete the news") {
           verify { mockNavActions.goBack() }

--- a/app/src/androidTest/java/com/swent/assos/NewsItemTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/NewsItemTest.kt
@@ -21,7 +21,8 @@ import org.junit.runner.RunWith
 @HiltAndroidTest
 class NewsItemTest : SuperTest() {
 
-  private val news = News(title = "title", description = "description")
+  private val news =
+      News(title = "title", description = "description", associationId = "1UYICvqVKbImYMNK3Sz3")
 
   override fun setup() {
     super.setup()
@@ -41,7 +42,10 @@ class NewsItemTest : SuperTest() {
           assertIsDisplayed()
           performClick()
         }
-        verify { mockNavActions.navigateTo(Destinations.NEWS_DETAILS.route + "/${news.id}") }
+        verify {
+          mockNavActions.navigateTo(
+              Destinations.NEWS_DETAILS.route + "/${news.id}" + "/${news.associationId}")
+        }
         confirmVerified(mockNavActions)
       }
     }
@@ -59,7 +63,10 @@ class NewsItemTest : SuperTest() {
           assertIsDisplayed()
           performClick()
         }
-        verify { mockNavActions.navigateTo(Destinations.NEWS_DETAILS.route + "/${news.id}") }
+        verify {
+          mockNavActions.navigateTo(
+              Destinations.NEWS_DETAILS.route + "/${news.id}" + "/${news.associationId}")
+        }
         confirmVerified(mockNavActions)
       }
     }

--- a/app/src/main/java/com/swent/assos/model/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/swent/assos/model/navigation/NavigationGraph.kt
@@ -75,9 +75,10 @@ fun NavigationGraph(navController: NavHostController = rememberNavController()) 
               assoId = backStackEntry.arguments?.getString("assoId").toString(),
               navigationActions = navigationActions)
         }
-        composable(Destinations.NEWS_DETAILS.route + "/{newsId}") { backStackEntry ->
+        composable(Destinations.NEWS_DETAILS.route + "/{newsId}" + "/{assoId}") { backStackEntry ->
           NewsDetails(
               newsId = backStackEntry.arguments?.getString("newsId").toString(),
+              assoId = backStackEntry.arguments?.getString("assoId").toString(),
               navigationActions = navigationActions)
         }
         composable(Destinations.STAFF_MANAGEMENT.route + "/{eventId}") { backStackEntry ->

--- a/app/src/main/java/com/swent/assos/model/view/CreateNewsViewModel.kt
+++ b/app/src/main/java/com/swent/assos/model/view/CreateNewsViewModel.kt
@@ -57,4 +57,8 @@ constructor(
   fun removeImage(image: Uri) {
     _news.value = _news.value.copy(images = _news.value.images - image)
   }
+
+  fun setEventId(eventId: String) {
+    _news.value = _news.value.copy(eventId = eventId)
+  }
 }

--- a/app/src/main/java/com/swent/assos/ui/components/DeleteButton.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/DeleteButton.kt
@@ -6,5 +6,5 @@ import androidx.compose.runtime.Composable
 
 @Composable
 fun DeleteButton(callBack: () -> Unit) {
-  BasicButtonWithIcon(buttonName = "", callback = callBack, icon = Icons.Default.Delete)
+  BasicButtonWithIcon(buttonName = "Delete", callback = callBack, icon = Icons.Default.Delete)
 }

--- a/app/src/main/java/com/swent/assos/ui/components/HomeItem.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/HomeItem.kt
@@ -52,13 +52,14 @@ fun HomeItem(id: String, navigationActions: NavigationActions) {
 
   val news = allNews.find { it.id == id } ?: News()
 
-  if (news.eventId != "") {
+  /*if (news.eventId != "") {
     eventViewModel.getEvent(news.eventId)
     assoId = event.associationId
-  }
+  }*/
 
   title = news.title
   description = news.description
+  assoId = news.associationId
 
   Box(
       modifier =
@@ -68,7 +69,7 @@ fun HomeItem(id: String, navigationActions: NavigationActions) {
               .clickable {
                 navigationActions.navigateTo(
                     if (news.eventId == "") {
-                      Destinations.NEWS_DETAILS.route + "/${news.id}"
+                      Destinations.NEWS_DETAILS.route + "/${news.id}" + "/${assoId}"
                     } else {
                       Destinations.EVENT_DETAILS.route + "/${news.eventId}" + "/${assoId}"
                     })

--- a/app/src/main/java/com/swent/assos/ui/components/NewsItem.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/NewsItem.kt
@@ -41,7 +41,8 @@ fun NewsItem(news: News, navigationActions: NavigationActions) {
         Column(
             modifier =
                 Modifier.width(200.dp).clickable {
-                  navigationActions.navigateTo(Destinations.NEWS_DETAILS.route + "/${news.id}")
+                  navigationActions.navigateTo(
+                      Destinations.NEWS_DETAILS.route + "/${news.id}" + "/${news.associationId}")
                 },
             horizontalAlignment = Alignment.CenterHorizontally) {
               if (news.images.isNotEmpty()) {

--- a/app/src/main/java/com/swent/assos/ui/screens/News.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/News.kt
@@ -39,7 +39,10 @@ fun News(navigationActions: NavigationActions) {
   val listState = rememberLazyListState()
   val loading = viewModel.loading.collectAsState()
 
-  LaunchedEffect(key1 = Unit) { viewModel.loadAllNews() }
+  LaunchedEffect(key1 = Unit) {
+    viewModel.loadNews()
+    viewModel.loadAllNews()
+  }
 
   Scaffold(modifier = Modifier.testTag("NewsScreen"), topBar = { PageTitle(title = "Home") }) {
       paddingValues ->

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/EventDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/EventDetails.kt
@@ -2,13 +2,8 @@ package com.swent.assos.ui.screens.assoDetails
 
 import android.widget.Toast
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.ChipColors
@@ -125,9 +120,28 @@ fun EventDetails(eventId: String, navigationActions: NavigationActions, assoId: 
       modifier = Modifier.semantics { testTagsAsResourceId = true }.testTag("EventDetails"),
       topBar = {
         PageTitleWithGoBack(
-            title = asso.acronym,
+            title = event.title,
             navigationActions = navigationActions,
-            actionButton = { DeleteButton { conf = true } })
+            actionButton = {
+              Row {
+                Text(
+                    text = asso.acronym,
+                    style =
+                        TextStyle(
+                            textDecoration = TextDecoration.Underline,
+                            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        ),
+                    textDecoration = TextDecoration.Underline,
+                    modifier =
+                        Modifier.padding(end = 16.dp).clickable {
+                          navigationActions.navigateTo(
+                              Destinations.ASSO_DETAILS.route + "/${assoId}")
+                        })
+              }
+            })
       },
       floatingActionButton = {
         if (!(associations.map { it.id }.contains(assoId)) &&
@@ -141,6 +155,7 @@ fun EventDetails(eventId: String, navigationActions: NavigationActions, assoId: 
               label = { labelStaffButton() },
           )
         }
+        DeleteButton { conf = true }
       },
       floatingActionButtonPosition = FabPosition.Center) { paddingValues ->
         if (conf) {

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/EventDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/EventDetails.kt
@@ -1,6 +1,7 @@
 package com.swent.assos.ui.screens.assoDetails
 
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,10 +28,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.swent.assos.R
 import com.swent.assos.model.navigation.Destinations
@@ -66,7 +70,31 @@ fun EventDetails(eventId: String, navigationActions: NavigationActions, assoId: 
 
   Scaffold(
       modifier = Modifier.semantics { testTagsAsResourceId = true }.testTag("EventDetails"),
-      topBar = { PageTitleWithGoBack(title = asso.acronym, navigationActions = navigationActions) },
+      topBar = {
+        PageTitleWithGoBack(
+            title = event.title,
+            navigationActions = navigationActions,
+            actionButton = {
+              Row {
+                Text(
+                    text = asso.acronym,
+                    style =
+                        TextStyle(
+                            textDecoration = TextDecoration.Underline,
+                            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        ),
+                    textDecoration = TextDecoration.Underline,
+                    modifier =
+                        Modifier.padding(end = 16.dp).clickable {
+                          navigationActions.navigateTo(
+                              Destinations.ASSO_DETAILS.route + "/${assoId}")
+                        })
+              }
+            })
+      },
       floatingActionButton = {
         if (event.id != "") {
           when ((associations.map { it.id }.contains(assoId))) {

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/NewsDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/NewsDetails.kt
@@ -3,8 +3,10 @@ package com.swent.assos.ui.screens.assoDetails
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -38,15 +40,20 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
 import com.swent.assos.R
+import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
+import com.swent.assos.model.view.AssoViewModel
 import com.swent.assos.model.view.NewsViewModel
 import com.swent.assos.model.view.ProfileViewModel
 import com.swent.assos.ui.components.DeleteButton
@@ -54,17 +61,23 @@ import com.swent.assos.ui.components.PageTitleWithGoBack
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun NewsDetails(newsId: String, navigationActions: NavigationActions) {
+fun NewsDetails(newsId: String, assoId: String, navigationActions: NavigationActions) {
 
   val viewModel: NewsViewModel = hiltViewModel()
   val specificNews by viewModel.news.collectAsState()
   val profileViewModel: ProfileViewModel = hiltViewModel()
   val associations by profileViewModel.memberAssociations.collectAsState()
   var conf by remember { mutableStateOf(false) }
+
+  val assoViewModel: AssoViewModel = hiltViewModel()
+  val association by assoViewModel.association.collectAsState()
+
   LaunchedEffect(key1 = Unit) {
     viewModel.loadNews(newsId)
     profileViewModel.updateUser()
+    assoViewModel.getAssociation(assoId)
   }
+
   Scaffold(
       modifier = Modifier.semantics { testTagsAsResourceId = true }.testTag("NewsDetailsScreen"),
       floatingActionButton = {
@@ -74,7 +87,29 @@ fun NewsDetails(newsId: String, navigationActions: NavigationActions) {
       },
       floatingActionButtonPosition = FabPosition.Center,
       topBar = {
-        PageTitleWithGoBack(title = specificNews.title, navigationActions = navigationActions)
+        PageTitleWithGoBack(
+            title = specificNews.title,
+            navigationActions = navigationActions,
+            actionButton = {
+              Row {
+                Text(
+                    text = association.acronym,
+                    style =
+                        TextStyle(
+                            textDecoration = TextDecoration.Underline,
+                            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        ),
+                    textDecoration = TextDecoration.Underline,
+                    modifier =
+                        Modifier.padding(end = 16.dp).clickable {
+                          navigationActions.navigateTo(
+                              Destinations.ASSO_DETAILS.route + "/${assoId}")
+                        })
+              }
+            })
       }) { paddingValues ->
         if (conf) {
           ConfirmDialog(

--- a/app/src/main/java/com/swent/assos/ui/screens/manageAsso/createEvent/CreateEvent.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/manageAsso/createEvent/CreateEvent.kt
@@ -90,7 +90,7 @@ fun CreateEvent(
                         createNewsViewModel.setTitle(event.title)
                         createNewsViewModel.setDescription(event.description)
                         createNewsViewModel.addImages(listOf(event.image))
-                        news.eventId = event.id
+                        createNewsViewModel.setEventId(event.id)
                         createNewsViewModel.createNews(assoId, onSuccess = {}, onError = {})
                       }
                       .padding(vertical = 5.dp, horizontal = 10.dp)


### PR DESCRIPTION
### Context :

Up until now, the screens displaying the details of the News or Events of the associations didn't necessarily specify the association that published that News or Event. If it wasn't said in the title or the description their was no way of knowing who produced it. 

In this Pull Request I implement a clickable text on the top right of the News and Event details pages displaying the acronym of the association. Also allowing the user to click on this acronym to access the page of the Association.

### Modifications :

- `NewsDetails` : Modified the `TopBar` of the screen to take a small text which displays the News' association `acronym`, I made this text clickable so it would navigate to the `Association`'s page. I also changed the parameters of the Composable to take the ID of the association that published the `News`.  In order to get the name of the association, I initialised a `AssoViewModel` in order to get the `Association` that published the News.
- `EventDetails` : Modified the `TopBar` of the screen to take a small text which displays the Event's association `acronym`. I made this text clickable so it would navigate to the `Association`'s page.
- `NavigationGraph` : Updated the route to `NewsDetails` to take the `assoId` as an extra parameter. Also modified the concerned composables ( those that were calling NewsDetails).
- `News` : While conducting manual testing, I realised the `News` of the associations the user is following were not displayed. I therefore added a call the `NewsViewModel` to load the `followingNews`.
- `CreateEvent` : While conducting manual testing, I realised the `Events` weren't displayed on the `News` screen. So I modified the `CreateNewsViewModel` to implement a function to set the eventId field. And then called this function from the `CreateEvent` screen so each event would have a news associated to it. 

### Testing :

-`NewsDetailsTest` :  Added a test to verify the display of the association's acronym on the top right of the screen. The test also clicks on the acronym and verifies the navigation to the association's page `AssoDetails` works properly. 

Achieved an overall **91.7% line coverage** on the new code.




https://github.com/The-Software-Enterprise/assos/assets/145565065/7e31e51b-bbf7-441d-a777-69b086420875




