### PR TITLE
Display the committee and backend

### DIFF
--- a/app/src/androidTest/java/com/swent/assos/AssoDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/AssoDetailsTest.kt
@@ -98,8 +98,11 @@ class AssoDetailsTest : SuperTest() {
     run {
       ComposeScreen.onComposeScreen<AssoDetailsScreen>(composeTestRule) {
         step("Check if the committee button is displayed") {
-          composeTestRule.onNodeWithText("The Committee").assertIsDisplayed()
+          composeTestRule.waitUntil(
+              condition = { composeTestRule.onNodeWithText("The Committee").isDisplayed() },
+              timeoutMillis = 10000)
         }
+
         step("Click on the committee button") {
           composeTestRule.onNodeWithText("The Committee").performClick()
         }

--- a/app/src/androidTest/java/com/swent/assos/AssoDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/AssoDetailsTest.kt
@@ -1,6 +1,7 @@
 package com.swent.assos
 
 import androidx.activity.compose.setContent
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -89,6 +90,20 @@ class AssoDetailsTest : SuperTest() {
 
     composeTestRule.activity.setContent {
       AssoDetails(assoId = assoId, navigationActions = mockNavActions)
+    }
+  }
+
+  @Test
+  fun testNavigationToCommitteeDetails() {
+    run {
+      ComposeScreen.onComposeScreen<AssoDetailsScreen>(composeTestRule) {
+        step("Check if the committee button is displayed") {
+          composeTestRule.onNodeWithText("The Committee").assertIsDisplayed()
+        }
+        step("Click on the committee button") {
+          composeTestRule.onNodeWithText("The Committee").performClick()
+        }
+      }
     }
   }
 

--- a/app/src/androidTest/java/com/swent/assos/AssoDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/AssoDetailsTest.kt
@@ -94,23 +94,6 @@ class AssoDetailsTest : SuperTest() {
   }
 
   @Test
-  fun testNavigationToCommitteeDetails() {
-    run {
-      ComposeScreen.onComposeScreen<AssoDetailsScreen>(composeTestRule) {
-        step("Check if the committee button is displayed") {
-          composeTestRule.waitUntil(
-              condition = { composeTestRule.onNodeWithText("The Committee").isDisplayed() },
-              timeoutMillis = 10000)
-        }
-
-        step("Click on the committee button") {
-          composeTestRule.onNodeWithText("The Committee").performClick()
-        }
-      }
-    }
-  }
-
-  @Test
   fun followAsso() {
     DataCache.currentUser.value.following = emptyList()
     run {

--- a/app/src/androidTest/java/com/swent/assos/CommitteeDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/CommitteeDetailsTest.kt
@@ -4,13 +4,16 @@ import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.swent.assos.model.data.CommitteeMember
 import com.swent.assos.model.data.User
 import com.swent.assos.model.serialize
+import com.swent.assos.screens.AssoDetailsScreen
 import com.swent.assos.screens.CreateNewsScreen
+import com.swent.assos.ui.screens.assoDetails.AssoDetails
 import com.swent.assos.ui.screens.assoDetails.CommitteeDetails
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.kakaocup.compose.node.element.ComposeScreen
@@ -43,6 +46,28 @@ class CommitteeDetailsTest : SuperTest() {
         .collection("committee")
         .document(member.id)
         .set(member)
+  }
+
+  @Test
+  fun testNavigationToCommitteeDetails() {
+
+    composeTestRule.activity.setContent {
+      AssoDetails(assoId = assoId, navigationActions = mockNavActions)
+    }
+
+    run {
+      ComposeScreen.onComposeScreen<AssoDetailsScreen>(composeTestRule) {
+        step("Check if the committee button is displayed") {
+          composeTestRule.waitUntil(
+              condition = { composeTestRule.onNodeWithText("The Committee").isDisplayed() },
+              timeoutMillis = 10000)
+        }
+
+        step("Click on the committee button") {
+          composeTestRule.onNodeWithText("The Committee").performClick()
+        }
+      }
+    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/swent/assos/CommitteeDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/CommitteeDetailsTest.kt
@@ -1,0 +1,98 @@
+package com.swent.assos
+
+import androidx.activity.compose.setContent
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import com.swent.assos.model.data.CommitteeMember
+import com.swent.assos.model.data.User
+import com.swent.assos.model.serialize
+import com.swent.assos.screens.AssoDetailsScreen
+import com.swent.assos.screens.CreateNewsScreen
+import com.swent.assos.ui.screens.assoDetails.AssoDetails
+import com.swent.assos.ui.screens.assoDetails.CommitteeDetails
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@HiltAndroidTest
+class CommitteeDetailsTest : SuperTest() {
+
+  val associationName = "JE EPFL"
+  val assoId = "9hciFZwTKU9rWg4r0B2A"
+
+  val member =
+      CommitteeMember(
+          id = "111111Member",
+          memberId = "111111User",
+          position = "President",
+          rank = 1,
+      )
+
+  val user = User(id = "111111User", firstName = "Jules", lastName = "Schneuwly", email = "")
+
+  override fun setup() {
+    super.setup()
+    Firebase.firestore.collection("users").document(user.id).set(serialize(user))
+    Firebase.firestore
+        .collection("associations")
+        .document(assoId)
+        .collection("committee")
+        .document(member.id)
+        .set(member)
+  }
+
+  @Test
+  fun testNavigationToCommitteeDetails() {
+    composeTestRule.activity.setContent {
+      AssoDetails(navigationActions = mockNavActions, assoId = assoId)
+    }
+
+    run {
+      ComposeScreen.onComposeScreen<AssoDetailsScreen>(composeTestRule) {
+        step("Check if the committee button is displayed") {
+          composeTestRule.onNodeWithText("The Committee").assertIsDisplayed()
+        }
+        step("Click on the committee button") {
+          composeTestRule.onNodeWithText("The Committee").performClick()
+        }
+      }
+    }
+  }
+
+  @Test
+  fun testCommitteeDetails() {
+    composeTestRule.activity.setContent {
+      CommitteeDetails(
+          navigationActions = mockNavActions, assoId = assoId, assoName = associationName)
+    }
+
+    run {
+      ComposeScreen.onComposeScreen<CreateNewsScreen>(composeTestRule) {
+        step("Check if the title is displayed") {
+          composeTestRule
+              .onNodeWithText("Members of the committee of " + associationName)
+              .assertIsDisplayed()
+        }
+        step("Check if the members are displayed") {
+          composeTestRule.waitUntil(
+              condition = { composeTestRule.onNodeWithText("Jules Schneuwly").isDisplayed() },
+              timeoutMillis = 10000)
+
+          composeTestRule.onNodeWithText("Jules Schneuwly").assertIsDisplayed()
+          composeTestRule.waitUntil(
+              condition = { composeTestRule.onNodeWithText("President").isDisplayed() },
+              timeoutMillis = 10000)
+
+          composeTestRule.onNodeWithText("President").assertIsDisplayed()
+        }
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/swent/assos/CommitteeDetailsTest.kt
+++ b/app/src/androidTest/java/com/swent/assos/CommitteeDetailsTest.kt
@@ -4,16 +4,13 @@ import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.swent.assos.model.data.CommitteeMember
 import com.swent.assos.model.data.User
 import com.swent.assos.model.serialize
-import com.swent.assos.screens.AssoDetailsScreen
 import com.swent.assos.screens.CreateNewsScreen
-import com.swent.assos.ui.screens.assoDetails.AssoDetails
 import com.swent.assos.ui.screens.assoDetails.CommitteeDetails
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.github.kakaocup.compose.node.element.ComposeScreen
@@ -46,24 +43,6 @@ class CommitteeDetailsTest : SuperTest() {
         .collection("committee")
         .document(member.id)
         .set(member)
-  }
-
-  @Test
-  fun testNavigationToCommitteeDetails() {
-    composeTestRule.activity.setContent {
-      AssoDetails(navigationActions = mockNavActions, assoId = assoId)
-    }
-
-    run {
-      ComposeScreen.onComposeScreen<AssoDetailsScreen>(composeTestRule) {
-        step("Check if the committee button is displayed") {
-          composeTestRule.onNodeWithText("The Committee").assertIsDisplayed()
-        }
-        step("Click on the committee button") {
-          composeTestRule.onNodeWithText("The Committee").performClick()
-        }
-      }
-    }
   }
 
   @Test

--- a/app/src/androidTest/java/com/swent/assos/screens/CommitteeScreen.kt
+++ b/app/src/androidTest/java/com/swent/assos/screens/CommitteeScreen.kt
@@ -1,0 +1,17 @@
+package com.swent.assos.screens
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.hasTestTag
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class CommitteeScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
+    ComposeScreen<CommitteeScreen>(
+        semanticsProvider = semanticsProvider,
+        viewBuilderAction = { hasTestTag("CommitteeScreen") }) {
+
+  val newsList: KNode = onNode { hasTestTag("CommitteeList") }
+  val CommitteeListItem: KNode = newsList.child { hasTestTag("NewsListItem") }
+  val CommitteeItemColumn: KNode = CommitteeListItem.child { hasTestTag("NewsItemColumn") }
+  val CommitteMemeberName: KNode = CommitteeItemColumn.child { hasTestTag("NewsItemsTitle") }
+}

--- a/app/src/main/java/com/swent/assos/model/data/CommitteeMember.kt
+++ b/app/src/main/java/com/swent/assos/model/data/CommitteeMember.kt
@@ -1,0 +1,8 @@
+package com.swent.assos.model.data
+
+data class CommitteeMember(
+    val id: String = "",
+    val memberId: String = "",
+    val position: String = "",
+    val rank: Int = 0,
+)

--- a/app/src/main/java/com/swent/assos/model/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/swent/assos/model/navigation/NavigationGraph.kt
@@ -14,6 +14,7 @@ import com.swent.assos.model.view.AppViewModel
 import com.swent.assos.ui.login.LoginScreen
 import com.swent.assos.ui.login.SignUpScreen
 import com.swent.assos.ui.screens.assoDetails.AssoDetails
+import com.swent.assos.ui.screens.assoDetails.CommitteeDetails
 import com.swent.assos.ui.screens.assoDetails.EventDetails
 import com.swent.assos.ui.screens.assoDetails.NewsDetails
 import com.swent.assos.ui.screens.manageAsso.ApplicationManagement
@@ -148,6 +149,13 @@ fun NavigationGraph(navController: NavHostController = rememberNavController()) 
               navigationActions = navigationActions,
               eventId = backStackEntry.arguments?.getString("eventId") ?: "")
         }
+        composable(Destinations.COMMITTEE_DETAILS.route + "/{assoId}" + "/{assoName}") {
+            backStackEntry ->
+          CommitteeDetails(
+              navigationActions = navigationActions,
+              assoId = backStackEntry.arguments?.getString("assoId") ?: "",
+              assoName = backStackEntry.arguments?.getString("assoName") ?: "")
+        }
       }
 }
 
@@ -174,5 +182,6 @@ enum class Destinations(val route: String) {
   APPLICATIONS("Applications"),
   SAVED("Saved"),
   CREATE_POSITION("CreatePosition"),
-  POS_DETAILS("PosDetails")
+  POS_DETAILS("PosDetails"),
+  COMMITTEE_DETAILS("CommitteeDetails")
 }

--- a/app/src/main/java/com/swent/assos/model/service/DbService.kt
+++ b/app/src/main/java/com/swent/assos/model/service/DbService.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import com.google.firebase.firestore.DocumentSnapshot
 import com.swent.assos.model.data.Applicant
 import com.swent.assos.model.data.Association
+import com.swent.assos.model.data.CommitteeMember
 import com.swent.assos.model.data.Event
 import com.swent.assos.model.data.News
 import com.swent.assos.model.data.OpenPositions
@@ -189,4 +190,6 @@ interface DbService {
       onSuccess: () -> Unit,
       onError: (String) -> Unit
   )
+
+  suspend fun getCommittee(associationId: String): List<CommitteeMember>
 }

--- a/app/src/main/java/com/swent/assos/model/service/impl/DbServiceImpl.kt
+++ b/app/src/main/java/com/swent/assos/model/service/impl/DbServiceImpl.kt
@@ -731,14 +731,14 @@ constructor(
         }
         .addOnFailureListener { onError(it.message ?: "Error fetching user details") }
 
-      val querySnapshot = firestore.collection("associations/$assoId/committee").get().await()
+    val querySnapshot = firestore.collection("associations/$assoId/committee").get().await()
 
-      for (document in querySnapshot.documents) {
-          val member = deserializeCommitteeMember(document)
-          if (member.memberId == userId) {
-              firestore.collection("associations/$assoId/committee").document(document.id).delete()
-          }
+    for (document in querySnapshot.documents) {
+      val member = deserializeCommitteeMember(document)
+      if (member.memberId == userId) {
+        firestore.collection("associations/$assoId/committee").document(document.id).delete()
       }
+    }
   }
 
   override suspend fun updateBanner(associationId: String, banner: Uri) {

--- a/app/src/main/java/com/swent/assos/model/utils.kt
+++ b/app/src/main/java/com/swent/assos/model/utils.kt
@@ -27,6 +27,7 @@ import com.google.zxing.MultiFormatWriter
 import com.google.zxing.common.BitMatrix
 import com.swent.assos.model.data.Applicant
 import com.swent.assos.model.data.Association
+import com.swent.assos.model.data.CommitteeMember
 import com.swent.assos.model.data.Event
 import com.swent.assos.model.data.News
 import com.swent.assos.model.data.OpenPositions
@@ -214,6 +215,14 @@ fun deserializeApplicant(doc: DocumentSnapshot): Applicant {
       userId = doc.getString("userId") ?: "",
       status = doc.getString("status") ?: "unknown",
       createdAt = timestampToLocalDateTime(doc.getTimestamp("createdAt")))
+}
+
+fun deserializeCommitteeMember(doc: DocumentSnapshot): CommitteeMember {
+  return CommitteeMember(
+      id = doc.id,
+      memberId = doc.getString("memberId") ?: "",
+      position = doc.getString("position") ?: "unknown",
+      rank = doc.getLong("rank")?.toInt() ?: 0)
 }
 
 fun serialize(user: User): Map<String, Any> {

--- a/app/src/main/java/com/swent/assos/model/view/AssoViewModel.kt
+++ b/app/src/main/java/com/swent/assos/model/view/AssoViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.swent.assos.model.AssociationPosition
 import com.swent.assos.model.data.Association
+import com.swent.assos.model.data.CommitteeMember
 import com.swent.assos.model.data.DataCache
 import com.swent.assos.model.data.Event
 import com.swent.assos.model.data.News
@@ -30,6 +31,9 @@ constructor(
 ) : ViewModel() {
   val currentUser = DataCache.currentUser.asStateFlow()
 
+  private val _committee = MutableStateFlow(emptyList<CommitteeMember>())
+  val committee = _committee.asStateFlow()
+
   private val _association = MutableStateFlow(Association())
   val association = _association.asStateFlow()
 
@@ -47,6 +51,10 @@ constructor(
 
   private val _positions = MutableStateFlow<List<OpenPositions>>(emptyList())
   val positions = _positions.asStateFlow()
+
+  fun getCommittee(associationId: String) {
+    viewModelScope.launch(ioDispatcher) { _committee.value = dbService.getCommittee(associationId) }
+  }
 
   fun getPositions(associationId: String) {
     viewModelScope.launch(ioDispatcher) { _positions.value = dbService.getPositions(associationId) }

--- a/app/src/main/java/com/swent/assos/ui/components/CommitteeItem.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/CommitteeItem.kt
@@ -1,0 +1,64 @@
+package com.swent.assos.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.swent.assos.R
+import com.swent.assos.model.view.UserViewModel
+
+@Composable
+fun CommitteeItem(userId: String, position: String) {
+
+  val viewModel: UserViewModel = hiltViewModel()
+  val user by viewModel.user.collectAsState()
+
+  LaunchedEffect(key1 = Unit) { viewModel.getUser(userId) }
+
+  Box(
+      modifier =
+          Modifier.background(MaterialTheme.colorScheme.background)
+              .fillMaxWidth()
+              .height(100.dp)
+              .testTag("CommitteeListItem")) {
+        Column(
+            modifier =
+                Modifier.padding(start = 16.dp, top = 20.dp)
+                    .align(Alignment.Center)
+                    .testTag("CommitteeItemColumn"),
+            verticalArrangement = Arrangement.spacedBy(5.dp),
+            horizontalAlignment = Alignment.Start) {
+              Text(
+                  modifier = Modifier.testTag("CommitteMemeberName"),
+                  text = user.firstName + " " + user.lastName,
+                  fontSize = 20.sp,
+                  fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+                  fontWeight = FontWeight.SemiBold,
+                  color = MaterialTheme.colorScheme.onBackground)
+              Text(
+                  modifier = Modifier.weight(1f).testTag("CommitteMemeberPosition"),
+                  text = position,
+                  fontSize = 14.sp,
+                  fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+                  color = MaterialTheme.colorScheme.onBackground)
+            }
+      }
+}

--- a/app/src/main/java/com/swent/assos/ui/components/HomeItem.kt
+++ b/app/src/main/java/com/swent/assos/ui/components/HomeItem.kt
@@ -52,11 +52,6 @@ fun HomeItem(id: String, navigationActions: NavigationActions) {
 
   val news = allNews.find { it.id == id } ?: News()
 
-  /*if (news.eventId != "") {
-    eventViewModel.getEvent(news.eventId)
-    assoId = event.associationId
-  }*/
-
   title = news.title
   description = news.description
   assoId = news.associationId

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/AssoDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/AssoDetails.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,16 +15,16 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Accessibility
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
 import androidx.compose.material3.FabPosition
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -36,14 +35,12 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -52,10 +49,9 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.rememberAsyncImagePainter
 import com.swent.assos.R
-import com.swent.assos.model.data.Association
+import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.AssoViewModel
-import com.swent.assos.model.view.ProfileViewModel
 import com.swent.assos.ui.components.EventItem
 import com.swent.assos.ui.components.NewsItem
 import com.swent.assos.ui.components.PostionItem
@@ -75,8 +71,6 @@ fun AssoDetails(assoId: String, navigationActions: NavigationActions) {
 
   val listStateNews = rememberLazyListState()
   val listStateEvents = rememberLazyListState()
-
-  val listStatePos = rememberLazyListState()
 
   val context = LocalContext.current
 
@@ -99,7 +93,7 @@ fun AssoDetails(assoId: String, navigationActions: NavigationActions) {
   LaunchedEffect(listStateEvents) {
     snapshotFlow { listStateEvents.layoutInfo.visibleItemsInfo }
         .collect { visibleItems ->
-          if (visibleItems.isNotEmpty() && visibleItems.last().index == events.size - 1) {
+          if (visibleItems.lastOrNull()?.index == events.size - 1) {
             viewModel.getMoreEvents(assoId)
           }
         }
@@ -254,6 +248,20 @@ fun AssoDetails(assoId: String, navigationActions: NavigationActions) {
       }
 
       item {
+        Button(
+            modifier =
+                Modifier.testTag("CommitteeButton").padding(30.dp).width(250.dp).height(60.dp),
+            shape = RoundedCornerShape(16.dp),
+            onClick = {
+              navigationActions.navigateTo(
+                  Destinations.COMMITTEE_DETAILS.route + "/${assoId}" + "/${association.acronym}")
+            }) {
+              Icon(imageVector = Icons.Default.Accessibility, contentDescription = null)
+              Text("The Committee", modifier = Modifier.padding(start = 12.dp), fontSize = 18.sp)
+            }
+      }
+
+      item {
         Text(
             text = "Latest Positions",
             style = MaterialTheme.typography.headlineMedium,
@@ -278,112 +286,7 @@ fun AssoDetails(assoId: String, navigationActions: NavigationActions) {
                   modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
         }
       }
-
-      item {
-        Text(
-            text = "The Committee",
-            style = MaterialTheme.typography.headlineMedium,
-            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-            fontWeight = FontWeight.Bold,
-            modifier =
-                Modifier.padding(horizontal = 16.dp, vertical = 10.dp).clickable {
-                  navigationActions.navigateTo(
-                      Destinations.COMMITTEE_DETAILS.route +
-                          "/${assoId}" +
-                          "/${association.acronym}")
-                })
-        Spacer(modifier = Modifier.height(50.dp))
-      }
-      item { Spacer(modifier = Modifier.height(20.dp)) }
+      item { Spacer(modifier = Modifier.height(60.dp)) }
     }
-  }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun TopAssoBar(asso: Association, navigationActions: NavigationActions, viewModel: AssoViewModel) {
-  val associationFollowed = viewModel.associationFollowed.collectAsState()
-  val profileViewModel: ProfileViewModel = hiltViewModel()
-
-  MediumTopAppBar(
-      colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
-      modifier = Modifier.testTag("Header"),
-      title = {
-        Text(
-            asso.acronym,
-            modifier = Modifier.testTag("Title"),
-            style =
-                TextStyle(
-                    fontSize = 30.sp,
-                    lineHeight = 32.sp,
-                    fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onBackground))
-      },
-      navigationIcon = {
-        Image(
-            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
-            imageVector = Icons.Default.ArrowBack,
-            contentDescription = null,
-            modifier = Modifier.testTag("GoBackButton").clickable { navigationActions.goBack() })
-      },
-      actions = {
-        if (asso.id != "") {
-          AssistChip(
-              colors =
-                  if (associationFollowed.value)
-                      AssistChipDefaults.assistChipColors(
-                          containerColor = MaterialTheme.colorScheme.surfaceVariant)
-                  else
-                      AssistChipDefaults.assistChipColors(
-                          containerColor = MaterialTheme.colorScheme.secondary),
-              border = null,
-              modifier = Modifier.testTag("FollowButton").padding(5.dp),
-              onClick = {
-                if (associationFollowed.value) {
-                  viewModel.unfollowAssociation(asso.id)
-                } else {
-                  viewModel.followAssociation(asso.id)
-                }
-                profileViewModel.updateNeeded()
-              },
-              label = {
-                if (associationFollowed.value) {
-                  Text(
-                      text = "Following",
-                      color = MaterialTheme.colorScheme.onSurfaceVariant,
-                      fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-                      fontWeight = FontWeight.Medium,
-                  )
-                } else {
-                  Text(
-                      text = "Follow",
-                      color = MaterialTheme.colorScheme.onSecondary,
-                      fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-                      fontWeight = FontWeight.Medium,
-                  )
-                }
-              },
-          )
-        }
-      })
-}
-
-@Composable
-fun JoinUsButton(onClick: () -> Unit, text: String = "Join us") {
-  FloatingActionButton(
-      onClick = onClick,
-      modifier = Modifier.height(42.dp).testTag("JoinButton"),
-      elevation = FloatingActionButtonDefaults.elevation(5.dp),
-      containerColor = MaterialTheme.colorScheme.primary,
-  ) {
-    Text(
-        modifier = Modifier.padding(horizontal = 10.dp),
-        text = text,
-        fontSize = 16.sp,
-        fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
-        fontWeight = FontWeight.SemiBold,
-        color = MaterialTheme.colorScheme.onPrimary,
-        style = MaterialTheme.typography.bodyMedium)
   }
 }

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/AssoDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/AssoDetails.kt
@@ -56,6 +56,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.rememberAsyncImagePainter
 import com.swent.assos.R
 import com.swent.assos.model.data.Association
+import com.swent.assos.model.navigation.Destinations
 import com.swent.assos.model.navigation.NavigationActions
 import com.swent.assos.model.view.AssoViewModel
 import com.swent.assos.model.view.ProfileViewModel
@@ -273,6 +274,22 @@ fun AssoDetails(assoId: String, navigationActions: NavigationActions) {
               style = MaterialTheme.typography.bodyMedium,
               modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
         }
+      }
+
+      item {
+        Text(
+            text = "The Committee",
+            style = MaterialTheme.typography.headlineMedium,
+            fontFamily = FontFamily(Font(R.font.sf_pro_display_regular)),
+            fontWeight = FontWeight.Bold,
+            modifier =
+                Modifier.padding(horizontal = 16.dp, vertical = 10.dp).clickable {
+                  navigationActions.navigateTo(
+                      Destinations.COMMITTEE_DETAILS.route +
+                          "/${assoId}" +
+                          "/${association.acronym}")
+                })
+        Spacer(modifier = Modifier.height(50.dp))
       }
       item { Spacer(modifier = Modifier.height(20.dp)) }
     }

--- a/app/src/main/java/com/swent/assos/ui/screens/assoDetails/CommitteeDetails.kt
+++ b/app/src/main/java/com/swent/assos/ui/screens/assoDetails/CommitteeDetails.kt
@@ -1,0 +1,56 @@
+package com.swent.assos.ui.screens.assoDetails
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.swent.assos.model.navigation.NavigationActions
+import com.swent.assos.model.view.AssoViewModel
+import com.swent.assos.ui.components.CommitteeItem
+import com.swent.assos.ui.components.PageTitleWithGoBack
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun CommitteeDetails(assoId: String, assoName: String, navigationActions: NavigationActions) {
+
+  val viewModel: AssoViewModel = hiltViewModel()
+  val committeeList by viewModel.committee.collectAsState()
+
+  val listState = rememberLazyListState()
+
+  LaunchedEffect(key1 = Unit) { viewModel.getCommittee(assoId) }
+
+  Scaffold(
+      modifier = Modifier.testTag("CommitteeScreen"),
+      topBar = {
+        PageTitleWithGoBack(title = "Members of the committee of " + assoName, navigationActions)
+      }) { paddingValues ->
+        LazyColumn(
+            modifier =
+                Modifier.padding(paddingValues)
+                    .padding(horizontal = 15.dp)
+                    .padding(vertical = 5.dp)
+                    .testTag("CommitteeList"),
+            verticalArrangement = Arrangement.spacedBy(15.dp),
+            userScrollEnabled = true,
+            state = listState) {
+              if (committeeList.isNotEmpty()) {
+                items(committeeList) { member -> CommitteeItem(member.memberId, member.position) }
+              } else {
+                item { Text(text = "No member in the committee") }
+              }
+            }
+      }
+}


### PR DESCRIPTION
### Context :

Until now the users of the application were unable to know who was part of the committee of each association. And each user was storing the information about their rank and their position in their associations, this was useless until now. 

### Implementations :

- `CommitteeMember.kt` : Implemented a data class for a committee member, this data class allows easier and faster handling of the database. Each `CommitteeMember` has 3 fields : `memberId`, `position`, `rank`. 
- `DbService`, `DbServiceImpl`, `AssoViewModel`, `utils.kt` : Implemented the `getCommittee` function to retrieve a list of the `CommitteeMember`s of the association. Modified the `joinAssociation` and `quitAssociation` functions to update the "committee" collection of each association when a members joins or leaves the association. 
- `CommitteeDetails.kt` : Implemented a new screen to display the list of `CommitteeMember`s of each association. 
- `CommitteeItem.kt` : Implemented a new component to represent each `CommitteeMember` of the association in the list. 
- `AssoDetails.kt` : Added a test "The Commitee" that users can click on to access the page `CommitteeDetails.kt`.
- `NavigationGraph.kt` : Added a route to access the `CommitteeDetails.kt` page.

### Testing :

- `CommitteeDetailsTest`, `CommitteeScreen` : 

   Implemented automatic testing to test the new feature : 
      One test to test the navigation,
      and another one to test the correct display of committee members.
     
   Achieving **94.3% line coverage** on the new code. 
   
   
   

https://github.com/The-Software-Enterprise/assos/assets/145565065/a20b0769-282c-45a1-8e92-f546a0a920a3

